### PR TITLE
Fix proof location enum

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,16 @@
 	"image": "mcr.microsoft.com/devcontainers/base:0",
 
 	"features": {
-		"ghcr.io/devcontainers/features/node:1": {}
+		"ghcr.io/devcontainers/features/node:1": {},
+		"ghcr.io/devcontainers/features/common-utils:2": {
+			"installZsh": true,
+			"configureZshAsDefaultShell": true,
+			"installOhMyZsh": true,
+			"installOhMyZshConfig": true,
+			"upgradePackages": true,
+			"username": "automatic",
+			"userUid": "automatic",
+			"userGid": "automatic"
+		  }
 	}
 }

--- a/docs/cow-protocol/reference/contracts/periphery/composable_cow.md
+++ b/docs/cow-protocol/reference/contracts/periphery/composable_cow.md
@@ -308,6 +308,12 @@ The `Proof.location` is intentionally not made an `enum` to allow for future ext
 | `WAKU` | `3` | `abi.encode(string protobufUri, string[] enrTreeOrMultiaddr, string contentTopic, bytes payload)` |
 | `IPFS` | `5` | `abi.encode(bytes32 ipfsCid)` |
 
+:::caution
+
+Locations above are for the point of defining a standard. The provided watch-tower currently does _not_ support Merkle Tree proofs for orders.
+
+:::
+
 <details closed>
     <summary>JSON schema for proofs</summary>
 

--- a/docs/cow-protocol/reference/contracts/periphery/composable_cow.md
+++ b/docs/cow-protocol/reference/contracts/periphery/composable_cow.md
@@ -304,8 +304,8 @@ The `Proof.location` is intentionally not made an `enum` to allow for future ext
 |---|---|---|
 | `PRIVATE` | `0` | `bytes("")` |
 | `LOG` | `1` | `abi.encode(bytes[] order)` where `order = abi.encode(bytes32[] proof, ConditionalOrderParams params)` |
-| `WAKU` | `2` | `abi.encode(string protobufUri, string[] enrTreeOrMultiaddr, string contentTopic, bytes payload)` |
-| `SWARM` | `3` | `abi.encode(bytes32 swarmCac)` |
+| `SWARM` | `2` | `abi.encode(bytes32 swarmCac)` |
+| `WAKU` | `3` | `abi.encode(string protobufUri, string[] enrTreeOrMultiaddr, string contentTopic, bytes payload)` |
 | `IPFS` | `5` | `abi.encode(bytes32 ipfsCid)` |
 
 <details closed>


### PR DESCRIPTION
The proof location enum now matches that found in cow-sdk

The below description / changes can be used if more context is required...

# Description

The proof location enum is defined in the `cow-sdk` and not specified in the contract. Therefore this should match the `cow-sdk`.

# Changes

- [x] Documentation matches `cow-sdk`