### PR TITLE
Bigger changes in concepts -> batch-auctions

### DIFF
--- a/docs/cow-protocol/concepts/batch-auctions/why-batch-auctions.md
+++ b/docs/cow-protocol/concepts/batch-auctions/why-batch-auctions.md
@@ -4,12 +4,12 @@ sidebar_position: 1
 
 # Why Batch Auctions?
 
-On CoW Protocol, users place orders off-chain which get collected and aggregated to be settled in batches. CoW Protocol replaces a central operator with an open solver competition for order matching. The term _solver_ refers to anyone who submits an order settlement solution for a batch. As soon as a batch is "closed for orders," meaning that it stops considering new orders, these solvers enter a competition to provide optimized solutions matching the orders in this closed batch.The number of batches the protocol executes depends on the trading frequency users choose. The shorter the expiry date of an order, the more batch auctions the protocol will conduct in order to settle the orders. If the expiry date is longer, the amount of batch auctions can be reduced as the protocol fits more trades in a single batch.
+On CoW Protocol, users place orders off-chain which get collected and aggregated to be settled in batches. CoW Protocol replaces a central operator with an open solver competition for order matching. The term _solver_ refers to anyone who submits an order settlement solution for a batch. As soon as a batch is "closed for orders," meaning that it stops considering new orders, these solvers enter a competition to provide optimized solutions matching the orders in this closed batch.
 
 ## Benefits of Batch Auctions
 
 Using batch auctions as a price finding mechanism has several benefits:
 
-1. Allow the DeFi space to establish a uniform clearing price for any token pair within the same block
-2. Improve prices over traditional DEX offerings through new economic mechanisms such as uniform clearing prices and Coincidence of Wants (CoWs)
-3. MEV Protection
+1. Allow the DeFi space to establish a **uniform clearing price** for any token pair within the same block
+2. Having the solver submit a single transaction containing multiple orders means their execution **can not** be reordered in search for MEV opportunities
+3. **Improve prices over traditional DEX offerings** via gas and liquidity flow optimizations enabled by settling multiple orders together


### PR DESCRIPTION
1 paragraph suggested that the number or frequency of batch auctions is influenced by the order duration of each user which is not the case

And the advantages bullet points seemed pretty repetitive and vague. My proposed wording is not great but roughly indicates what I think would be important benefits of batch auctions.

On an related note: That page has a drop down menu "On this page" with a single entry. Can this be removed until we have more items in the page?