### PR TITLE
Update uniform-clearing-prices.md

### DIFF
--- a/docs/cow-protocol/concepts/batch-auctions/uniform-clearing-prices.md
+++ b/docs/cow-protocol/concepts/batch-auctions/uniform-clearing-prices.md
@@ -10,4 +10,8 @@ Constant Function Market Makers (CFMMs), of which AMMs are an example, do not al
 
 The mechanism of CFMMs means the order of transactions is very important in determining prices, which in turn leads to Maximal Extractable Value (MEV) as a phenomenon. 
 
-Batch auctions solve for this problem by ensuring all trades within a batch execute for the same uniform clearing price, making transaction order irrelevant. In theory, this practice could extend to the entirety of an Ethereum block, making transaction order irrelevant for all orders in a block. With CoW Protocol leveraging Batch Auctions, traders in Ethereum can now get the same price for the same token pairs they trade at the exact same block.
+Batch auctions solve for this problem by ensuring all trades within a batch execute for the same uniform clearing price, making transaction order irrelevant. 
+In theory, this practice could extend to the entirety of an Ethereum block: a block builder could order transactions in a way that minimize the difference in exchange rates of tokens that are traded more than once.
+However, block builder incentives are currently set in a way to achieve the exact opposite: the larger the difference between highest and lowest price of an asset within a block, the more profit someone that buys the asset at its lowest and sells it at its highest price can extract.
+
+With CoW Protocol leveraging Batch Auctions, traders in Ethereum can now get the same price for the same token pairs they trade at the exact same block and thus fundamentally reduce the amount of extractable value.


### PR DESCRIPTION
# Description

I wasn't happy with the phrasing of how UCP could be achieved on Ethereum in theory today. Frankly, I think it's incorrect. Transactions will always be executed sequentially against the most recent state and thus achieving it on the core protocol level is impossible. Even if a "close to optimal" ordering of txs existed, it's very unstable (every change to the ordering would break UCP)

# Changes

- [x] Rephrase how uniform clearing prices could be achieved in theory on Ethereum today
- [x] Highlight how the current incentives achieve the exact opposite
- [x] #99 

<!--
## Related Issues

Fixes #
-->
