### PR TITLE
Drop duplicated sentence

### DIFF
--- a/docs/cow-protocol/tutorials/integrations/scripts/how-to-submit-orders-via-the-api/2.-query-the-fee-endpoint.md
+++ b/docs/cow-protocol/tutorials/integrations/scripts/how-to-submit-orders-via-the-api/2.-query-the-fee-endpoint.md
@@ -4,8 +4,6 @@ Placing an order is free in CoW Protocol and only requires signing an off chain 
 
 If your order is matched and executed the gas cost of settling it is taken over by the solver. As a consequence, solvers have to be reimbursed that cost in the form of a trading fee. This fee is charged in the token you are selling and the exact amount depends on the route and amount you are trading.
 
-Placing an order is free and only requires signing an off chain message. Order execution is then done by so-called "solvers". If your order is matched and executed the gas cost of settling it is taken over by the solver. As a consequence solvers have to be reimbursed that cost in the form of a trading fee. This fee is charged in the token you are selling and the exact amount mainly depends on the route and amount you are trading.
-
 The API provides a single endpoint to get a quote (fee + amount estimate) for your order. Orders that don’t specify a high enough fee will be rejected by the API. The fee estimate is valid for a short period of time (long enough for you to sign and send the final order).
 
 In order to quote the current fee to trade 10,000 USDC for WETH you can query:
@@ -26,7 +24,7 @@ curl -X POST -H  "accept: application/json" -H  "Content-Type: application/json"
 }' https://api.cow.fi/mainnet/api/v1/quote
 ```
 
-**Note, that the amount is given in “atoms”** (smallest unit of the token, e.g. wei for ETH). With USDC having 6 decimals, 10k USDC equals 10e10 atoms.\\
+**Note, that the amount is given in “atoms”** (smallest unit of the token, e.g. wei for ETH). With USDC having 6 decimals, 10k USDC equals 10e10 atoms.
 
 The response contains a quote object containing a ready to be signed order with all relevant fields as well as some metadata regarding the validity of the quote and the account that should be used for signing.
 
@@ -36,4 +34,4 @@ In the example above the minimum fee for the order would be about 66 USDC and yo
 
 The fee is always paid on top of the specified sell amount. In the query we asked to sell 10k USDC **before fees** meaning that the sell amount was reduced by the fee amount (feeAmount + sellAmount = 10k USDC in the response). You can also provide **sellAmountAfterFees** in which case the sell Amount will be exactly the specified amount (make sure to have sufficient additional balance to pay for the fee). For buy orders specify set `kind` to _buy_ and pass **buyAmountAfterFee** (since fee is always taken in the sell token there is no differentiation in this case)
 
-Depending on your use case you may discard the estimated buy/sell amount. In case you don't please note that **the provided quote** **doesn't include any slippage.** This means that the tiniest price move may make your order un-fillable. In order to increase your settlement chances especially in volatile conditions we advise you add a slippage tolerance of at least 0.3%. Our solvers ensure that setting a slippage on your order doesn’t make you prone to MEV attacks is given in "atoms" - e.g. wei for ETH) **before fee**
+Depending on your use case you may discard the estimated buy/sell amount. In case you don't please note that **the provided quote doesn't include any slippage.** This means that the tiniest price move may make your order un-fillable. In order to increase your settlement chances especially in volatile conditions we advise you add a slippage tolerance of at least 0.3%. Our solvers ensure that setting a slippage on your order doesn’t make you prone to MEV attacks is given in "atoms" - e.g. wei for ETH) **before fee**


### PR DESCRIPTION
The page also has a `''` which seems odd.
Is this intended to separate the paragraphs? In that case there are probably better options.
