### PR TITLE
Mention that the API does not accept exploitable orders

### DIFF
--- a/docs/cow-protocol/tutorials/integrations/scripts/how-to-submit-orders-via-the-api/4.-signing-the-order.md
+++ b/docs/cow-protocol/tutorials/integrations/scripts/how-to-submit-orders-via-the-api/4.-signing-the-order.md
@@ -47,4 +47,4 @@ The ultimate source of truth for signature verification is the smart contract’
 
 Do not sign orders with simultaneously `sellAmount == 0`, `buyAmount == 0`, and `partiallyFillable == false`.&#x20;
 
-Because of a known issue in the contracts, such orders can be settled unlimited times, which means that any solver could take the fee amount multiple times. There is normally no reason to generate such "empty" order. However, you should consider this case if you are signing orders that come from potentially untrusted sources.
+Because of a known issue in the contracts, such orders can be settled unlimited times, which means that any solver could take the fee amount multiple times. There is normally no reason to generate such "empty" orders and the API even rejects those orders. However, you should consider this case if you are signing orders that come from potentially untrusted sources.


### PR DESCRIPTION
Also Anxo would probably mad that you suggest putting random bytes in the `appdata` (or rather a hash that does not point to a document with the expected JSON format). 😄
