### PR TITLE
Update _token_approvals.mdx

### DIFF
--- a/docs/partials/_token_approvals.mdx
+++ b/docs/partials/_token_approvals.mdx
@@ -1,10 +1,6 @@
 :::caution
 
-A user should be careful when signing approval transactions. Verify carefully that:
-
-- The token address is correct (in this case {props.token}'s address)
-- The spender address is correct (in this case {props.spender}'s address)
-- The amount is correct
+A user should be careful when signing approval transactions. Verify carefully that the spender address is correct (in this case {props.spender}'s address).
 
 If in doubt about any of the above, do *not* sign the transaction. To review your approvals, you can use https://revoke.cash/.
 


### PR DESCRIPTION
# Description

I think it's fine to only verify the spender as if your spender is not malicious setting an allowance for the wrong token/amount is unfortunate but not a risk.
