### PR TITLE
Update _receiver.mdx

### DIFF
--- a/docs/partials/_receiver.mdx
+++ b/docs/partials/_receiver.mdx
@@ -1,13 +1,13 @@
 :::danger Warning
 
-Ensure that the `receiver` address is correct. Fake CoW Swap websites have been observed and often substitute this parameter with their own address. This **should be set to  `0x0000000000000000000000000000000000000000` or your signer's address** to indicate that the tokens will be sent to your signer's address. If you have set a custom receiver, you should verify that the address is correct.
+Ensure that the `receiver` address is correct. Fake CoW Swap websites have been observed and often substitute this parameter with their own address. 
+This **should be set to  0x0...0 or your signer's address** to indicate that the tokens will be sent to the order signer's address. 
+If you have set a custom receiver, you should verify that the address is correct.
 
 The user interface should display a warning if the `receiver` address is not the address from which you are signing the trade intent.
 
 :::
 
-:::caution
-
-Be very careful when signing an intent to trade. All of the associated parameters are final and cannot be changed once the intent is signed and submitted to the API. If you make a mistake, you will need to cancel the intent and create a new one.
-
-:::
+Be careful when signing an intent to trade. 
+All of the associated parameters are final and cannot be changed once the intent is signed and submitted to the API. 
+If you make a mistake, you will need to [cancel](tutorials/cow-swap/cancel) the intent and create a new one.


### PR DESCRIPTION
# Description

I personally find this view of the swap tutorial too scary and not visually appealing
<img width="995" alt="image" src="https://github.com/cowprotocol/docs-v2/assets/1200333/8d315bba-1085-445c-ad95-12e41159671f">

Not sure if it's worth putting this in a partial?

# Changes

<!-- List of detailed changes (how the change is accomplished) -->

- [ ] One line per sentence
- [ ] Make the receiver less ugly to read
- [ ] Clarify it's the order signer that receives funds
- [ ] Remove below caution tooltip for regular text.
- [ ] Link to cancel tutorial

<!--
## Related Issues

Fixes #
-->
