### PR TITLE
Update signing_schemes.mdx

### DIFF
--- a/docs/cow-protocol/reference/core/signing_schemes.mdx
+++ b/docs/cow-protocol/reference/core/signing_schemes.mdx
@@ -23,7 +23,7 @@ When computing the domain separator, the following parameters are used:
   name: "Gnosis Protocol",
   version: "v2",
   chainId: /* chain ID for the current network: eg. 1 for mainnet */,
-  verifyingContract: /* address of the settlement contract */
+  verifyingContract: "0x9008D19f58AAbD9eD0D60971565AA8510560ab41"
 }
 ```
 
@@ -111,19 +111,17 @@ const digest = hashOrder(domain(1, "0x9008D19f58AAbD9eD0D60971565AA8510560ab41")
 console.log(`Order digest: ${digest}`)
 ```
 
+### Etherscan Example
+
+For convenience, we also deployed a small helper contract that make it easy to compute order uids as well as their full encoding for each chain using the Etherscan UI:
+
+- [Mainnet](https://etherscan.io/address/0xe84dcd8587287b997f51299430a396ad03aaec06#readContract)
+- [Gnosis Chain](https://gnosisscan.io/address/0xCA51403B524dF7dA6f9D6BFc64895AD833b5d711#code)
+- [Goerli](https://goerli.etherscan.io/address/0x6FAE2a52b1ef43cCC8dAe49ed902571c17a9e354#readContract)
+
 ## Supported schemes
 
-CoW Protocol supports four different signing schemes:
-
-```mermaid
-flowchart TD
-    A[Settlement] -->|EOA Only| B[EIP-712]
-    A -->|EOA Only| C[Eth-Sign]
-    A -->|Contract Only| D[EIP-1271]
-    A -->|Contract & EOA| E[PreSign]
-```
-
-These signing schemes are summarized in the following table:
+CoW Protocol supports four different signing schemes. These signing schemes are summarized in the following table:
 
 | **Signing Scheme** | **Gas-less** | **EOA** | **Smart Contract** |
 |---|---|---|---|
@@ -206,7 +204,7 @@ isValidSignature(orderDigest, eip1271Signature) == MAGICVALUE
 
 This is the only signing method that supports both EOA and smart-contract traders.
 
-Before submitting a `PreSign` order, the user must pre-approve the order on-chain. This is done by calling the settlement contract `setPreSignature` function:
+Together with submitting a `PreSign` order, the user must pre-approve the order on-chain. This is done by calling the settlement contract `setPreSignature` function:
 
 ```solidity
 setPreSignature(orderUid, true);
@@ -215,12 +213,6 @@ setPreSignature(orderUid, true);
 The components are:
 - `orderUid`, the unique identifier of the order
 - `true`, whether the order is pre-signed or not (allows for cancelling pre-signed orders)
-
-:::caution
-
-If the `setPreSignature` on-chain transaction has not been confirmed before submitting the `PreSign` order, the order will be rejected.
-
-:::
 
 The signature is an empty `bytes` string:
 

--- a/docs/cow-protocol/reference/core/signing_schemes.mdx
+++ b/docs/cow-protocol/reference/core/signing_schemes.mdx
@@ -113,11 +113,11 @@ console.log(`Order digest: ${digest}`)
 
 ### Etherscan Example
 
-For convenience, we also deployed a small helper contract that make it easy to compute order uids as well as their full encoding for each chain using the Etherscan UI:
+For convenience, we also deployed a small helper contract that makes it easy to compute order uids as well as their full encoding for each chain using the Etherscan UI:
 
-- [Mainnet](https://etherscan.io/address/0xe84dcd8587287b997f51299430a396ad03aaec06#readContract)
-- [Gnosis Chain](https://gnosisscan.io/address/0xCA51403B524dF7dA6f9D6BFc64895AD833b5d711#code)
-- [Goerli](https://goerli.etherscan.io/address/0x6FAE2a52b1ef43cCC8dAe49ed902571c17a9e354#readContract)
+- [Mainnet](https://etherscan.io/address/0xe84dcd8587287b997f51299430a396ad03aaec06#readContract#F1)
+- [Gnosis Chain](https://gnosisscan.io/address/0xCA51403B524dF7dA6f9D6BFc64895AD833b5d711#readContract#F1)
+- [Goerli](https://goerli.etherscan.io/address/0x6FAE2a52b1ef43cCC8dAe49ed902571c17a9e354#readContract#F1)
 
 ## Supported schemes
 


### PR DESCRIPTION
# Description

<!--- Describe your changes to provide context for reviewers, including why it is needed -->

# Changes

<!-- List of detailed changes (how the change is accomplished) -->

- [x] Add a handly little contract I deployed for computing order UIDs and encodings using the Etherscan UI
- [x] Remove wrong caution that you cannot place a pre-sign order before it's confirmed on-chain (this is how the Safe UI currently does it)
- [x] Remove redundant graph that was not containing any additional information compared to the existing table

<!--
## Related Issues

Fixes #
-->
