### PR TITLE
chore: fix links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 CoW DAO is on a mission to innovate the most user-protective products in Ethereum. 
 
-Currently, CoW DAO’s two main products are [**CoW Protocol**](cow-protocol) and **MEV Blocker**, which it supports with development and marketing resources – including the CoW Grants Program, the CoW Protocol Explorer, and the [CoW Swap frontend](cow-protocol/tutorials/cow-swap).
+Currently, CoW DAO’s two main products are [**CoW Protocol**](cow-protocol) and [**MEV Blocker**](https://mevblocker.io), which it supports with development and marketing resources – including the [CoW Grants Program](governance/grants), the [CoW Protocol Explorer](cow-protocol/tutorials/cow-explorer), and the [CoW Swap frontend](cow-protocol/tutorials/cow-swap).
 
 ## What is [CoW Protocol](cow-protocol)? 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 CoW DAO is on a mission to innovate the most user-protective products in Ethereum. 
 
-Currently, CoW DAO’s two main products are [**CoW Protocol**](cow-protocol) and **MEV Blocker**, which it supports with development and marketing resources – including the CoW Grants Program, the CoW Protocol Explorer, and the [CoW Swap frontend](cow-protocol/create/cowswap-ui).
+Currently, CoW DAO’s two main products are [**CoW Protocol**](cow-protocol) and **MEV Blocker**, which it supports with development and marketing resources – including the CoW Grants Program, the CoW Protocol Explorer, and the [CoW Swap frontend](cow-protocol/tutorials/cow-swap).
 
 ## What is [CoW Protocol](cow-protocol)? 
 

--- a/docs/cow-protocol/concepts/introduction/solvers.md
+++ b/docs/cow-protocol/concepts/introduction/solvers.md
@@ -10,4 +10,4 @@ Once a user submits an intent, the protocol hands it off to solvers who compete 
 
 Solvers can move tokens on behalf of the user (using the `ERC20` approvals the user granted to the vault relayer contract) while the settlement contract verifies the signature of the user's intent and ensures that execution happens according to the limit price and quantity specified by the user.
 
-Anyone with some DeFi knowledge and ability to code an optimizations algorithm can [create a solver](../../solve/create).
+Anyone with some DeFi knowledge and ability to code an optimizations algorithm can [create a solver](../../tutorials/solvers/create).

--- a/docs/cow-protocol/concepts/product-features/builder-friendly/README.md
+++ b/docs/cow-protocol/concepts/product-features/builder-friendly/README.md
@@ -4,13 +4,13 @@ With a strong focus on welcoming builders to the protocol, CoW Protocol is desig
 
 Areas that are welcoming to builders include:
 
-- [Programmatic orders](../programmatic)
-    - [Composable CoW](composable-cow)
-- [Solvers](../../solve/create)
+- [Programmatic orders](programmatic)
+    - [Composable CoW](./builder-friendly/composable-cow)
+- [Solvers](../../tutorials/solvers/create)
 
 ## Built on CoW Protocol
 
 The Grants DAO is a community-run DAO that funds projects that build on top of CoW Protocol. Successfully funded projects include:
 
-* [Milkman](milkman) - A way for users to initiate a swap and ensure that their price is respected by the protocol
-* [Composable CoW](composable-cow) - A way for developers to build conditional orders on top of CoW Protocol's support for programmatic orders
+* [Milkman](./builder-friendly/milkman) - A way for users to initiate a swap and ensure that their price is respected by the protocol
+* [Composable CoW](./builder-friendly/composable-cow) - A way for developers to build conditional orders on top of CoW Protocol's support for programmatic orders

--- a/docs/cow-protocol/concepts/product-features/builder-friendly/composable-cow.md
+++ b/docs/cow-protocol/concepts/product-features/builder-friendly/composable-cow.md
@@ -1,6 +1,5 @@
 ---
 sidebar_position: 6
-draft: true
 ---
 
 # Composable CoW

--- a/docs/cow-protocol/concepts/product-features/market-orders.md
+++ b/docs/cow-protocol/concepts/product-features/market-orders.md
@@ -8,8 +8,13 @@ Market orders are orders to buy or sell tokens as soon as possible at the curren
 They are essenitally limit orders where the limit price is close to or below the current market rate.
 In the context of CoW Protocol, when you place a market order, you agree to get, at minimum, the best price the protocol can find by quoting solvers for your order.
 This price is reduced by a user-defined "slippage tolerance" to ensure the trade executes even in volatile market conditions.
-Note, that unlike other DEXs, your slippage tolerance cannot be extracted by MEV Bots (cf. [MEV Protection](mev-protection)).
+
+:::note
+
+Unlike other DEXs, your slippage tolerance cannot be extracted by MEV Bots (cf. [MEV Protection](../batch-auctions/mev-protection)).
 If the solvers are able to find optimizations within the batch auction your order is settled with, you may also get a better price.
+
+:::
 
 Market orders are _fill or kill_, meaning that they either execute entirely or will not execute at all. 
 Thanks to CoW Protocol’s delegated trading model, market orders are different from other venue market orders, as orders are placed gaslessly and the user isn't charged any fees in the event of order expiration or failure.

--- a/docs/cow-protocol/concepts/product-features/programmatic.md
+++ b/docs/cow-protocol/concepts/product-features/programmatic.md
@@ -1,4 +1,5 @@
 ---
+slug: programmatic
 sidebar_position: 4
 ---
 
@@ -16,4 +17,4 @@ For example, a user can place a TWAP order that executes over 24 hours
 
 * **Stop loss orders**: Users can place an order that executes when the price of a token falls below a certain threshold
 
-* **Native ETH orders**: Users can place orders with `ETH`, which is not supported by the CoW Protocol settlement contract, but is able to be traded through CoW Protocol thanks to an [intermediary smart contract](periphery/eth-flow) that auto-converts `ETH` into `WETH` to later place an `ERC-1271` order (intent) on the user’s behalf
+* **Native ETH orders**: Users can place orders with `ETH`, which is not supported by the CoW Protocol settlement contract, but is able to be traded through CoW Protocol thanks to an [intermediary smart contract](../../reference/contracts/periphery/eth-flow) that auto-converts `ETH` into `WETH` to later place an `ERC-1271` order (intent) on the user’s behalf

--- a/docs/cow-protocol/reference/contracts/core/README.mdx
+++ b/docs/cow-protocol/reference/contracts/core/README.mdx
@@ -36,7 +36,7 @@ CoW Protocol contracts are deployed using deterministic addresses. This means th
 
 :::caution
 
-Take care when [signing](../../signing-schemes), ensuring that the `EIP-712` domain separator is specified correctly.
+Take care when [signing](../core/signing-schemes), ensuring that the `EIP-712` domain separator is specified correctly.
 
 :::
 

--- a/docs/cow-protocol/tutorials/cow-explorer/README.mdx
+++ b/docs/cow-protocol/tutorials/cow-explorer/README.mdx
@@ -2,8 +2,8 @@
 
 As CoW Protocol utilizes an off-chain order-book, and settles on-chain, getting a holistic view of the current state of CoW Protocol requires a combination of on-chain and off-chain data. Individually, this information is available from the following:
 
-- [OrderBook API](/docs/cow-protocol/reference/apis/orderbook) (off-chain)
-- [CoW Protocol Subgraph](/docs/cow-protocol/analyze/subgraph) (on-chain)
+- [OrderBook API](/cow-protocol/reference/apis/orderbook) (off-chain)
+- [CoW Protocol Subgraph](/cow-protocol/tutorials/analyze/subgraph) (on-chain)
 
 Switching between these tools, and reading raw JSON data is better suited for computers, not humans. To make it easier to view the current state of CoW Protocol, we've built a tool that combines the two, providing a convenient and holistic view of the current state of CoW Protocol.
 

--- a/docs/cow-protocol/tutorials/cow-swap/native.mdx
+++ b/docs/cow-protocol/tutorials/cow-swap/native.mdx
@@ -19,7 +19,7 @@ As a consequence, native tokens cannot be directly traded on CoW Protocol.
 However, there are two ways in which to still execute a swap from native tokens on CoW Protocol:
 
 1. Wrap the native token into an ERC20 token (eg. `ETH` to `WETH`) and then swap it on CoW Protocol; or
-2. Use the [Eth-flow](/docs/cow-protocol/reference/contracts/periphery/eth-flow) contract to place an order on your behalf.
+2. Use the [Eth-flow](/cow-protocol/reference/contracts/periphery/eth-flow) contract to place an order on your behalf.
 
 ## Wrapping native tokens
 
@@ -35,7 +35,7 @@ The CoW Swap UI has built-in support for wrapping native tokens. Simply select t
 
 ## Eth-flow
 
-In an attempt to smooth the user experience, CoW Protocol has introduced the [Eth-flow](/docs/cow-protocol/reference/contracts/periphery/eth-flow) contract. This allows users to automate the [above process](#wrap-native-tokens), all in one **on-chain** transaction.
+In an attempt to smooth the user experience, CoW Protocol has introduced the [Eth-flow](/cow-protocol/reference/contracts/periphery/eth-flow) contract. This allows users to automate the [above process](#wrap-native-tokens), all in one **on-chain** transaction.
 
 Using Eth-flow is transparent to the user in CoW Swap, simply select the native token you want to swap and the desired token. CoW Swap will automatically detect if the native token needs to be wrapped and will execute the Eth-flow contract on your behalf.
 

--- a/docs/cow-protocol/tutorials/cow-swap/swap.mdx
+++ b/docs/cow-protocol/tutorials/cow-swap/swap.mdx
@@ -15,8 +15,8 @@ Consider an example swapping 0.05 `WETH` for `COW`.
 
 ![GPv2VaultRelayer approval required](/img/cowswap/swap_need_approval.png)
 
-Oh, it looks like we need to approve the [`GPv2VaultRelayer`](/docs/cow-protocol/reference/contracts/core#gpv2vaultrelayer) to spend our `WETH`!
-This is because the [`GPv2VaultRelayer`](/docs/cow-protocol/reference/contracts/core#gpv2vaultrelayer) is the contract that will pull the `WETH` from our wallet and send it to the [settlement](/docs/cow-protocol/reference/contracts/core#gpv2settlement) contract that will co-ordinate the swap on our behalf.
+Oh, it looks like we need to approve the [`GPv2VaultRelayer`](/cow-protocol/reference/contracts/core#gpv2vaultrelayer) to spend our `WETH`!
+This is because the [`GPv2VaultRelayer`](/cow-protocol/reference/contracts/core#gpv2vaultrelayer) is the contract that will pull the `WETH` from our wallet and send it to the [settlement](/cow-protocol/reference/contracts/core#gpv2settlement) contract that will co-ordinate the swap on our behalf.
 Both contracts are audited, battle-tested and non-upgradeable.
 Moreover, the settlement contract is the only address that can request the relayer to pull your funds and only after verifying both that your order was signed by you and that you will receive at least your limit execution price or better. 
 
@@ -24,7 +24,7 @@ Moreover, the settlement contract is the only address that can request the relay
 
 :::tip
 
-Some tokens, such as `USDC`, `DAI`, and `COW` support permit-style approvals. This means that you can approve the [`GPv2VaultRelayer`](/docs/cow-protocol/reference/contracts/core#gpv2vaultrelayer) to spend your tokens without having any initial gas for an on-chain transaction. This is a great way to save on gas costs!
+Some tokens, such as `USDC`, `DAI`, and `COW` support permit-style approvals. This means that you can approve the [`GPv2VaultRelayer`](/cow-protocol/reference/contracts/core#gpv2vaultrelayer) to spend your tokens without having any initial gas for an on-chain transaction. This is a great way to save on gas costs!
 
 You don't have to worry about this, as CoW Swap will automatically detect if the token supports permit-style approvals and will guide you through the process.
 
@@ -32,7 +32,8 @@ You don't have to worry about this, as CoW Swap will automatically detect if the
 
 ![GPv2VaultRelayer default approval](/img/cowswap/swap_approval_default.png)
 
-By default, CoW Swap prompt you to approve [`GPv2VaultRelayer`](/docs/cow-protocol/reference/contracts/core#gpv2vaultrelayer) an "unlimited" allowance for the sell token. This has the benefits of:
+By default, CoW Swap prompt you to approve [`GPv2VaultRelayer`](/cow-protocol/reference/contracts/core#gpv2vaultrelayer) an "unlimited" allowance for the sell token.
+This has the benefits of:
 
 - Not having to approve multiple times
 - Save on gas costs
@@ -55,6 +56,7 @@ At this stage, your wallet will prompt you to sign the intent to swap. The user 
 
 ![Signing Swap](/img/cowswap/swap_signing.png)
 
-Once the intent has been signed, it will be submitted to CoW Protocol. You are able to [view your order](/docs/cow-protocol/view) on [CoW Explorer](https://explorer.cow.fi).
+Once the intent has been signed, it will be submitted to CoW Protocol.
+You are able to [view your order on CoW Explorer](/cow-protocol/tutorials/cow-explorer).
 
 ![Swap confirmed](/img/cowswap/swap_confirmed.png)

--- a/docs/cow-protocol/tutorials/integrations/programmatic/liquidation.mdx
+++ b/docs/cow-protocol/tutorials/integrations/programmatic/liquidation.mdx
@@ -185,7 +185,7 @@ While this approach is still theoretically possible, there is a much simpler and
 The reason that lending protocols want to stay in control of the caller context is to ensure that the debt is repaid atomically in the same transaction.
 
 While performing all steps atomically is the only secure way to achieve this if arbitrary addresses are allowed to kick the liquidation, it is actually not required if the liquidation is triggered via a CoW Protocol smart order (using ERC-1271).
-CoW Protocol's [settlement contract](/docs/cow-protocol/reference/contracts/core#gpv2settlement) passes a commitment to the **order parameters (ie. buy and sell amounts)** to the verifying smart contract as part of the signature verification step and, once authorized, **guarantees that the trader will receive at least** as much of the buy token as specified in the order. Otherwise the whole settlement will revert!
+CoW Protocol's [settlement contract](/cow-protocol/reference/contracts/core#gpv2settlement) passes a commitment to the **order parameters (ie. buy and sell amounts)** to the verifying smart contract as part of the signature verification step and, once authorized, **guarantees that the trader will receive at least** as much of the buy token as specified in the order. Otherwise the whole settlement will revert!
 
 This means that as long as the liquidation protocol verifies that the maximum sell amount (collateral) covers the minimum guaranteed buy amount (debt) it can "accept" the trade and rest assured that it will receive the required proceeds to make the position whole. The solver competition will ensure that, if market price permit, the protocol will even receive **more than the limit price** (surplus).
 

--- a/docs/cow-protocol/tutorials/solvers/README.mdx
+++ b/docs/cow-protocol/tutorials/solvers/README.mdx
@@ -1,7 +1,3 @@
----
-draft: true
----
-
 # Solving auctions
 
 ## What is a Solver?

--- a/docs/cow-protocol/tutorials/solvers/create.md
+++ b/docs/cow-protocol/tutorials/solvers/create.md
@@ -1,6 +1,5 @@
 ---
 sidebar_position: 1
-draft: true
 ---
 
 # Create a solver
@@ -24,7 +23,7 @@ Let us consider the case of [Yearn](https://yearn.fi) tokens. A user has `USDC` 
 
 :::tip Get the big picture
 
-CoW Protocol infrastructure is a lot of services running together in herd harmony, which is a bit intimidating at the beginning. Before proceeding, it would be advisable to read the [architectural overview](/cow-protocol/reference/architecture) to get a better understanding of how CoW Protocol works and its entities.
+CoW Protocol infrastructure is a lot of services running together in herd harmony, which is a bit intimidating at the beginning. Before proceeding, it would be advisable to read the architectural overview to get a better understanding of how CoW Protocol works and its entities.
 
 :::
 

--- a/docs/governance/grants.md
+++ b/docs/governance/grants.md
@@ -1,0 +1,5 @@
+---
+id: grants
+---
+
+# CoW Grants Program

--- a/docs/governance/process/README.mdx
+++ b/docs/governance/process/README.mdx
@@ -18,7 +18,7 @@ It is a best practice to create a CIP for any significant change to CoW DAO. Thi
 
 :::tip CIP Template
 
-Want to get started writing a CIP? Check out the [CIP template](template) to get started.
+Want to get started writing a CIP? Check out the [CIP template](./process/template) to get started.
 
 :::
 

--- a/docs/partials/_receiver.mdx
+++ b/docs/partials/_receiver.mdx
@@ -10,4 +10,4 @@ The user interface should display a warning if the `receiver` address is not the
 
 Be careful when signing an intent to trade. 
 All of the associated parameters are final and cannot be changed once the intent is signed and submitted to the API. 
-If you make a mistake, you will need to [cancel](tutorials/cow-swap/cancel) the intent and create a new one.
+If you make a mistake, you will need to [cancel](/cow-protocol/tutorials/cow-swap/cancel) the intent and create a new one.


### PR DESCRIPTION
# Description

There are some links that were broken because the pages were in `draft` mode (meaning that they don't show in the final build. Additionally there were general links that were broken irrespective of this.

# Changes

- [x] Remove `draft` status as docs are in `beta` (no need to shield `prod`) 
- [x] Fix general broken links
- [x] Some minor editorial changes

## Related Issues

Fixes #50