### PR TITLE
Simplify the math - use "surplus" instead of utility

### DIFF
--- a/docs/cow-protocol/reference/core/auctions/the_problem.md
+++ b/docs/cow-protocol/reference/core/auctions/the_problem.md
@@ -17,11 +17,9 @@ This is from the user's perspective, and is therefore net of fees.
 
 :::
 
-Clearly,  $$\mathbb R^k_+ \subset S$$, that is, a user is always willing to accept an order in which they receive a positive amount of tokens without paying anything. Similarly, $$\mathbb R^k_{-} \cap S = 0$$ because no user would accept to pay tokens without receiving anything. The interesting elements of the acceptance set are, therefore, those with at least one positive entry and at least one negative entry. We also assume that $$0 \in S$$, that is, when submitting an order a user accepts that the order may not be filled.
+We also assume that $$0 \in S$$ that is, when submitting an order a user accepts that the order may not be filled. Also, to each order $$S$$ we define _surplus_function_ $$U_S:S\rightarrow \mathbb R$$, measuring "how good" a trade is from the point of view of the user who submitted order _S_. By definition $$U_S(0)=0$$.
 
-To each order $$S$$ we may assign a _utility function_ $$U_S:S\rightarrow \mathbb R$$ specifying a numerical value to each trade in the acceptance set, to be interpreted as "how good" a trade is from the point of view of the user who submitted order _S_. By definition $$U_S(0)=0$$.
-
-Practically speaking, CoW Protocol allows only some types of orders, which we can think of as constraints on the set _S_ that a user can submit_._ One such constraint is that only pairwise swaps are allowed, that is, all vectors in $$S$$  have zeros in $$k-2$$ dimensions. Furthermore, each order must fit within one of the categories we now discuss. To simplify notation, when discussing these categories we assume that $$k=2$$.
+Practically speaking, CoW Protocol allows only some types of orders, which we can think of as constraints on the set _S_ that a user can submit. One such constraint is that only pairwise swaps are allowed, that is, all vectors in $$S$$  have zeros in $$k-2$$ dimensions. Furthermore, each order must fit within one of the categories we now discuss. To simplify notation, when discussing these categories, we assume that $$k=2$$.
 
 ### Limit Sell Orders
 
@@ -33,7 +31,7 @@ and a partially-fillable sell order has the form
 
 $$S= \left \{ \begin{bmatrix} x \\-y \end{bmatrix} ~~s.t. ~~\frac{y}{\pi} \leq x \hbox{ and } y \in [0,Y] \right \}.$$
 
-In both cases, the utility function is defined as
+In both cases, the surplus function is defined as
 
 $$U(x,-y)=(x-y / \pi)p(b)$$,
 
@@ -51,7 +49,7 @@ while partially-fillable limit buy orders have the form
 
 $$S = \left\{\begin{bmatrix} x \\-y \end{bmatrix}~~s.t.~~ y \leq x \cdot \pi \hbox{ and } x \in[0, X] \right\}.$$
 
-Again, the utility function is defined as
+Again, the surplus function is defined as
 
 $$U(\{x,-y\})=(x \cdot \pi-y)p(s)$$,
 
@@ -81,7 +79,7 @@ At CoW DAO's discretion, systematic violation of these rules may lead to penaliz
 :::
 
 
-From the protocol viewpoint, each solution that satisfies the above constraints has a _quality_ given by the sum of the utility generated, and the fees paid to the protocol:
+From the protocol viewpoint, each solution that satisfies the above constraints has a _quality_ given by the total surplus generated and the fees paid to the protocol:
 
 $$\sum_o U(o)+p\cdot \sum_of(o)$$,
 


### PR DESCRIPTION


# Description

The text was using the term "utility," whereas for consistency, it should have been "surplus". It was also a bit unnecessarily math-heavy at times, so I dropped some stuff.

# Changes

- [x] replace utility function with "surplus function"
- [x] drop the discussion about properties of acceptance sets that was not entirely relevant


