### PR TITLE
drop utility function

### DIFF
--- a/docs/cow-protocol/reference/core/auctions/README.mdx
+++ b/docs/cow-protocol/reference/core/auctions/README.mdx
@@ -1,5 +1,5 @@
 # Batch Auction mechanism
 
-Cow Protocol uses batch auctions for executing trades. Within a given batch, the goal is to compute prices and traded amounts in order to maximize a well-defined *utility function*. This can be formulated as a concrete optimization problem that needs to be solved, and this is where the Solvers comes into place.
+Cow Protocol uses batch auctions for executing trades. Within a given batch, the goal is to compute prices and traded amounts to maximize a well-defined function. This can be formulated as a concrete optimization problem that needs to be solved, and this is where the Solvers come into place.
 
 Informally, a _Solver_ is an algorithm that takes as input a batch auction _instance_ and outputs a batch auction _solution_, both described precisely in a formal language. The solution is then processed by the Protocol, which validates all Solver candidate solutions and ranks them according to a well-defined objective function.


### PR DESCRIPTION


# Description

here again we use the term utility function, which should be replaced with "surplus function" or just surplus. Although here it is just best to drop it and sat "maximize a well-defined function"
