### PR TITLE
Add technical specifications for hooks

### DIFF
--- a/docs/cow-protocol/concepts/product-features/cow-hooks.md
+++ b/docs/cow-protocol/concepts/product-features/cow-hooks.md
@@ -2,13 +2,13 @@
 sidebar_position: 3
 ---
 
+import HooksGuaranteesWarning from '../../reference/core/intents/_hooks_guarantees_warning.md'
+
 # CoW Hooks
 
-CoW hooks allow users to specify Ethereum calls (also known as an "inner transaction") alongside their orders that execute atomically before and after a CoW Protocol swap. These hooks come in two flavors:
+CoW hooks allow users to specify Ethereum calls alongside their orders that execute atomically before and after a CoW Protocol swap. These hooks come in two flavors:
 
-**"Pre-hooks"**: These are interactions that execute at the start of the settlement, before the swap. 
-Note that these are executed even before an order's signature is checked or sell tokens are transferred out of the user's account. 
-This allows pre-hooks to be used to "set up" an order. 
+**"Pre-hooks"**: These are interactions that execute at the start of the settlement, before the swap. This allows pre-hooks to be used to "set up" an order.
 For example:
 
 * Setting the required `ERC-20` approvals to the CoW Protocol using an `EIP-2612` permit, so approvals are only set if the order executes
@@ -21,20 +21,7 @@ For example:
 * Bridging trade proceeds to L2s
 * Staking trading proceeds
 
-It is also worth noting that any network fees for covering the execution cost of your hooks are also charged in the sell token, just like regular order execution fees.
+Any network fees for covering the execution cost of your hooks are also charged in the sell token, just like regular order execution fees.
 So you don't need to hold any particular token or extra `ETH` to use this feature!
 
-:::caution
-
-Hook execution is not guaranteed, meaning that your order may still get matched even if the hook reverted. 
-To ensure the execution of pre-hooks, make sure the trade is only possible if the hook is executed successfully (e.g. by setting the required allowance as part of it)
-
-:::
-
-:::note
-
-When placing _partially fillable_ orders with hooks, **pre-hooks will only be executed on the first fill**.
-Therefore, your hook should ensure that the liquidity is sufficient for the entire order to be filled.
-On the other hand, **post-hooks are executed on every fill**.
-
-:::
+<HooksGuaranteesWarning />

--- a/docs/cow-protocol/reference/core/intents/_hooks_guarantees_warning.md
+++ b/docs/cow-protocol/reference/core/intents/_hooks_guarantees_warning.md
@@ -1,0 +1,13 @@
+:::caution
+
+Hook execution is not guaranteed, meaning that your order may still get matched even if the hook reverted. 
+To ensure the execution of pre-hooks, make sure the trade is only possible if the hook is executed successfully (e.g. by setting the required allowance as part of it)
+
+:::
+
+:::caution
+
+Hook execution is not enforced by the CoW Protocol smart contracts.
+Solvers must include them as part of the [social consensus rules](../auctions/social-consensus).
+
+:::

--- a/docs/cow-protocol/reference/core/intents/cow-hooks.mdx
+++ b/docs/cow-protocol/reference/core/intents/cow-hooks.mdx
@@ -1,0 +1,61 @@
+---
+id: hooks
+sidebar_position: 2
+---
+
+import HooksGuaranteesWarning from "./_hooks_guarantees_warning.md";
+
+# Hooks
+
+The [CoW Hooks feature](/cow-protocol/concepts/product-features/cow-hooks) allows users to request the solvers to execute user-defined Ethereum calls (also known as an "inner/internal transaction") before and after the execution of an order in a settlement.
+
+## Specification
+
+There are two type of hooks available: `pre` and `post`.
+_Pre_ hooks are executed before any order signature is checked (in particular, before any funds are taken from the order owner).
+_Post_ hooks are executed after all orders in a batch are settled (that is, the proceeds of the orders have already been credited to the receiver).
+
+Both `pre` and `post` hooks are specified as an array of hooks.
+
+Each hook is described by three parameters:
+
+- `target`: the target address of the Ethereum call.
+
+  Using implementing EIP-2612 approvals as an example, this would be the token contract.
+
+- `callData`: the data of the Ethereum call.
+
+  In the example above, the ABI-encoded function call to `permit`.
+
+- `gasLimit`: a hard limit on the amount of gas needed by the call.
+
+  An order quote uses this value to estimate the total fee needed to execute an order.
+  The more gas needed, the higher fee will be needed for the order to be settled.
+
+  If the call requires more gas than specified here, the Ethereum call in the hook will be internally reverting _but the order will be executed regardless_.
+
+:::note
+
+When placing _partially fillable_ orders with hooks, **pre-hooks will only be executed on the first fill**.
+Therefore, your hook should ensure that the liquidity is sufficient for the entire order to be filled.
+On the other hand, **post-hooks are executed on every fill**.
+
+:::
+
+## Creating orders with hooks
+
+Orders are linked to hooks through the [app data](./app-data).
+
+As long as the full appdata with hook information is included when posting the order to the [orderbook API](../../apis/orderbook), the order will be stored with hook information included and settlements using this order will include its pre and post hooks.
+
+## Call context
+
+Hooks are executed through the [HooksTrampoline](../../contracts/periphery/hooks-trampoline).
+
+Anyone can execute calls using the trampoline, so you must not expect a call to the trampoline to be trusted.
+
+## Security
+
+<HooksGuaranteesWarning />
+
+The parameters of a hook are signed by the user along with the order as part of the app data.


### PR DESCRIPTION
# Description

We only have a "product feature" description for hooks. It's nicely written but it lacks a few technical details.

This PR splits that page in two: high level feature description and technical features". The technical features are expounded upon.

# Changes

- New technical page for hooks.
- Simplified hook feature page.
- Shared warning for critical knowledge.

## Related Tasks

PR #161 should be updated to link to the right page once this PR is merged.


