### PR TITLE
Phrasing nit (ie. -> example)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,6 @@ CoW DAO is of its community, by its community, and for its community. CoW DAO us
 
 CoW DAO’s documentation follows a "Concepts", "Procedures", "Technical Reference" methodology. For example when a user wants to learn:
 
-- **_What_** something is (ie. batch auctions) → see [Concepts](cow-protocol/concepts)
-- **_How_** to do something (ie. create an order) → see [Tutorials](cow-protocol/tutorials)
-- **_Technical_** information (ie. such as SDKs, APIs) - see [Technical Reference](cow-protocol/reference)
+- **_What_** something is (example: batch auctions) → see [Concepts](cow-protocol/concepts)
+- **_How_** to do something (example: create an order) → see [Tutorials](cow-protocol/tutorials)
+- **_Technical_** information (example: such as SDKs, APIs) - see [Technical Reference](cow-protocol/reference)


### PR DESCRIPTION
# Description

Fixes small misspelling and misuse of "i.e.". I went for "example:" instead of "e.g.," because I'm hoping to make the landing page more friendly.  