### PR TITLE
remove a constraint (block size) add a constraint (enough endowement)

### DIFF
--- a/docs/cow-protocol/reference/core/auctions/the_problem.md
+++ b/docs/cow-protocol/reference/core/auctions/the_problem.md
@@ -67,10 +67,10 @@ The fee of limit orders is again denominated in the sell token.
 
 ## Solution
 
-Solvers propose solutions to the protocol, where a solution is a set of trades to execute. Formally, suppose that there are $$I$$ users and _J_ liquidity sources. A solution is a list of trades $$\{o_1, o_2, ...o_I, l_1, l_2, ..., l_J\}$$ one per user and one per liquidity source such that:
+Solvers propose solutions to the protocol, where a solution is a set of trades to execute. Formally, suppose there are $$I$$ users and _J_ liquidity sources. A solution is a list of trades $$\{o_1, o_2, ...o_I, l_1, l_2, ..., l_J\}$$ one per user and one per liquidity source such that:
 
-* **Maximum size of solution**: The total number of executed orders and AMMs does not exceed a certain number within each batch due to limitations regarding the size of a block on the blockchain.
 * **Incentive compatibility and feasibility**: the trades respect the user and liquidity sources, that is, $$o_i\in S_i~~\forall i\leq I$$  and $$l_j \in L_j~~\forall j\leq J$$.
+* **Sufficient endowments**:  each user should have enough sell tokens in their wallet. Note that the protocol already performs this check at order creation. However, a user could move funds between order creation and execution or create multiple orders pledging the same sell amount multiple times. Hence, each solver should  also check that users' endowments are sufficient to execute the proposed solution.
 * **Uniform clearing prices**: all users must face the same prices. Importantly, this constraint is defined at the moment when the swap occurs. So, for example, suppose user _i_ receives _x_ units of token 1 in exchange for _y_ units of token 2 and that the protocol takes a fee in the sell token $$f_2$$. Define $$p_{1,2}=\frac{y-f_2}{x}$$ as the price at which the swap occurs. Uniform clearing prices means that $$p_{1,2}$$ is the same for all users swapping token 1 and token 2. Furthermore, prices must be consistent, in the sense that for any three tokens 1, 2, and 3, if $$p_{1,2},~ p_{2,3}, ~p_{1,3}$$ are well-defined, then it must be that $$p_{1,2}\cdot p_{2,3}=p_{1,3}$$. Note that this implies that prices can be expressed with respect to a common numéraire, giving rise to a uniform price clearing vector $$p$$.
 * [**Social consensus rules**](social-consensus): These are a set of principles that solvers should follow, which were voted by CIPs.
 


### PR DESCRIPTION

# Description
In the description of when a solution is valid, we used to say that it has to respect the block size. It seems redundant to specify that the solution needs to satisfy the basic constraints given by the blockchain (which, BTW, are more than simply block size). On the other hand, Felix L though we should specify that solvers also need to check that trader have enough tokens in their wallet

# Changes

- [x] remove a constraint (block size)
- [x] add a constraint (users' endowments)

<!--
## Related Issues

Fixes #
-->
