### PR TITLE
fix: vercel 404

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+    "cleanUrls": true
+}


### PR DESCRIPTION
# Description

Vercel is initially returning 404.html for subpages, which then results in JavaScript correctly loading the page. This causes issues with indexing / crawling.

# Changes

- [x] Use vercel-specific settings to allow clean URLs, preventing 404.