### PR TITLE
Autopilot docs

### DIFF
--- a/docs/cow-protocol/tutorials/arbitrate/README.mdx
+++ b/docs/cow-protocol/tutorials/arbitrate/README.mdx
@@ -59,13 +59,8 @@ sequenceDiagram
     driver1 ->>autopilot: Scored solution
     deactivate driver1
     Note over autopilot: Pick winner
-    autopilot->>driver0: /reveal
-    activate driver0
-    driver0->>autopilot: Encoded settlement
-    deactivate driver0
-    autopilot->>driver0: /settle
-    activate driver0;
-    Note right of driver0: Settles transaction onchain
+    autopilot->>+driver0: Request execution
+    Note over driver0: Settles transaction onchain
     driver0->>autopilot: Transaction hash
     deactivate driver0
     Note over autopilot: End

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -17,6 +17,8 @@ Its role can be broadly summarized into these main purposes.
    - Data availability consensus around which orders are valid for a given batch
    - The initial exchange rates for each traded tokens which are used to normalize surplus across different orders
 2. Solver competition
+   - Data availability consensus around the available solution candidates and their score
+   - Notifying the winning solver to submit their solution
 3. Auction data storage
 
 ```mermaid

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -22,7 +22,6 @@ Its role can be broadly summarized into these main purposes.
 
 ```mermaid
 sequenceDiagram
-    participant orderbook
     participant database
     participant blockchain
     participant autopilot
@@ -33,9 +32,6 @@ sequenceDiagram
     end
 
     par data retrieval
-      # database orders
-      orderbook->>database: Update database
-    and
       autopilot->>+database: Get order information
       database->>-autopilot: Uids, signatures, owners...
     and

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -6,13 +6,10 @@ sidebar_position: 1
 
 The autopilot is the engine that drives forward CoW Protocol.
 
-Running at a regular interval, it keeps an up-to-date view on the state of the protocol,
-synthesizes this data into an _auction_,
-broadcasts this auction to each of the solvers,
-and finally chooses which solution will be executed.
+Running at a regular interval, it keeps an up-to-date view on the state of the protocol, synthesizes this data into an _auction_, broadcasts this auction to each of the solvers, and finally chooses which solution will be executed.
 
 Users don't interact with the autopilot directly: its only intended interface is with the solvers.
-Unlike solvers, there is a single autopilot running for each chain[^barn].
+There is a single autopilot running for each chain[^barn].
 
 Its role can be broadly summarized into these main purposes.
 

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -111,7 +111,7 @@ Still, this doesn't mean that all orders that appear in the auction can be settl
 ## Solver competition
 
 Once an auction is ready, the autopilot sends a `/solve` request to each solver.
-Solvers have a short amount time (seconds) to come up with a [solution](/cow-protocol/reference/core/auctions/the-problem#solution) and return its _score_ to the autopilot, which represents the quality of a solution.
+Solvers have a short amount of time (seconds) to come up with a [solution](/cow-protocol/reference/core/auctions/the-problem#solution) and return its _score_ to the autopilot, which represents the quality of a solution.
 The scoring process is described in detail in the [description of CoW Protocol's optimization problem](/cow-protocol/reference/core/auctions/the-problem).
 The autopilot selects the winner according to the highest score once the allotted time expires or all solvers have returned their batch proposal.
 

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -11,7 +11,7 @@ synthesizes this data into an _auction_,
 broadcasts this auction to each of the solvers,
 and finally chooses which solution will be executed.
 
-Users don't interact with the autopilot directly: its only intended interface is with the solvers (through the driver).
+Users don't interact with the autopilot directly: its only intended interface is with the solvers.
 Unlike solvers, there is a single autopilot running for each chain[^barn].
 
 Its role can be broadly summarized into these main purposes.
@@ -29,10 +29,10 @@ sequenceDiagram
     participant database
     participant blockchain
     participant autopilot
-    box external drivers
-      participant driver 1
-      participant driver 2
-      participant driver 3
+    box external solvers
+      participant solver 1
+      participant solver 2
+      participant solver 3
     end
 
     par data retrieval
@@ -52,29 +52,29 @@ sequenceDiagram
     # auction
     Note over autopilot: Cut auction
     par broadcast current auction
-      autopilot->>driver 1: /solve
-      activate driver 1
+      autopilot->>solver 1: /solve
+      activate solver 1
     and
-      autopilot->>driver 2: /solve
-      activate driver 2
+      autopilot->>solver 2: /solve
+      activate solver 2
     and
-      autopilot->>driver 3: /solve
-      activate driver 3
+      autopilot->>solver 3: /solve
+      activate solver 3
     end
-    driver 3->>autopilot: Proposed batch
-    deactivate driver 3
-    driver 1->>autopilot: Proposed batch
-    deactivate driver 1
-    driver 2->>autopilot: Proposed batch
-    deactivate driver 2
+    solver 3->>autopilot: Proposed batch
+    deactivate solver 3
+    solver 1->>autopilot: Proposed batch
+    deactivate solver 1
+    solver 2->>autopilot: Proposed batch
+    deactivate solver 2
 
     Note over autopilot: Pick winner
-    autopilot->>+driver 2: /reveal
-    driver 2->>-autopilot: Ethereum transaction data
-    autopilot->>+driver 2: /settle
-    driver 2->>+blockchain: Execute transaction
-    blockchain->>-driver 2: Transaction receipt
-    driver 2->>-autopilot: Transaction hash
+    autopilot->>+solver 2: /reveal
+    solver 2->>-autopilot: Ethereum transaction data
+    autopilot->>+solver 2: /settle
+    solver 2->>+blockchain: Execute transaction
+    blockchain->>-solver 2: Transaction receipt
+    solver 2->>-autopilot: Transaction hash
 
     autopilot->>database: Store auction data
 ```
@@ -119,13 +119,13 @@ This steps tries to guarantees that all available orders can be settled on CoW P
 
 ## Solver competition
 
-Once an auction is ready, the autopilot sends a `/solve` request to each solver's driver.
+Once an auction is ready, the autopilot sends a `/solve` request to each solver.
 Solvers have a short amount time (seconds) to come up with a [solution](/cow-protocol/core/auctions/the-problem#solution) and return its _score_ to the autopilot.
-The autopilot selects the winner based on this score once the allotted time expires or all drivers have returned their batch proposal.
+The autopilot selects the winner based on this score once the allotted time expires or all solvers have returned their batch proposal.
 
 Up to this point, the autopilot only knows the score and not the full solution that achieves that score.
 The autopilot then asks the winning solver to reveal its score (throug `/reveal`) and then to execute the corresponding settlement transaction (`/settle`).
-The solver is responsible for executing the transaction onchain (through the driver).
+The solver is responsible for executing the transaction onchain (through the [driver](driver)).
 
 ## Auction data storage
 

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -97,7 +97,11 @@ Native token price fetching is handled by an integrated price estimator in the a
 The price is fetched from multiple sources and may change based on the current configurations.
 Prices are both queried from a list of selected existing solvers as well as retrieved internally by the autopilot (for example, by querying some external parties like Paraswap and 1inch, but also by reading onchain pool data as Uniswap).
 
-Orders that can't be settled are filtered out: these are expired orders, those with not enough balance, with missing approvals, or that use tokens that aren't supported by the protocol.
+Orders that can't be settled are filtered out. This is the case if, for example:
+* an order is expired
+* the user's balance isn't enough to settle the order
+* the approval to the vault relayer is missing
+* the involved tokens aren't supported by the protocol
 
 The autopilot also checks that [ERC-1271](/cow-protocol/reference/core/signing-schemes#erc-1271) signatures are currently valid.
 

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 # Autopilot

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -101,8 +101,6 @@ Orders that can't be settled are filtered out: these are expired orders, those w
 
 The autopilot also checks that [ERC-1271](/cow-protocol/reference/core/signing-schemes#erc-1271) signatures are currently valid.
 
-This steps tries to guarantees that all available orders can be settled on CoW Protocol without further checks from the solvers.
-
 ## Solver competition
 
 Once an auction is ready, the autopilot sends a `/solve` request to each solver.

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -36,9 +36,6 @@ sequenceDiagram
     and
       autopilot->>+blockchain: Get order information
       blockchain->>-autopilot: Onchain cancellations, ETH flow...
-    and
-      autopilot->>+blockchain: Get liquidity
-      blockchain->>-autopilot: Uniswap, Balancer, ...
     end
 
     # auction
@@ -89,16 +86,14 @@ Other information can only be retrieved onchain and is updated every time a new 
 - Detecting if a batch has been settled and it should prepare a new auction
 
 Retrieved information isn't limited to the CoW Protocol itself.
-The aution data also contains information on which liquidity is available to the solvers to settle an auction's orders.
-Solvers may use this liquidity information to help them out with finding a solution more quickly.
-Some liquidity sources are also used to provide a reference price of each token in an order;
+The autopilot needs to provide a reference price for each token in an order (a numéraire);
 the reference price is used to normalize the value of the [surplus](/cow-protocol/reference/core/auctions/the-problem), since the surplus must be comparable for all orders and an order could use the most disparate ERC-20 tokens.
+The reference token is usually the chain's native token, since it's the token used to pay for the gas needed when executing a transaction. 
+Orders whose price can't be fetched are discarded and won't be included in an auction.
 
-Examples of liquidity sources that are tracked by the autopilot:
-- Uniswap (v2 and v3)
-- Balancer (Weighted, Weighted2Token, ComposableStable, ...)
-- SushiSwap
-- Swapr
+Native token price fetching is handled by a integrated price estimator in the autopilot.
+The price is fetched from multiple sources and may change based on the current configurations.
+Prices are both queried from a list of selected existing solvers as well as retrieved internally to the autopilot (for example, by querying some external parties like Paraswap and 1inch, but also by reading onchain pool data as Uniswap).
 
 Orders that can't be settled are filtered out: these are expired orders, those with not enough balance, with missing approvals, or that use tokens that aren't supported by the protocol.
 

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -111,9 +111,9 @@ Still, this doesn't mean that all orders that appear in the auction can be settl
 ## Solver competition
 
 Once an auction is ready, the autopilot sends a `/solve` request to each solver.
-Solvers have a short amount time (seconds) to come up with a [solution](/cow-protocol/reference/core/auctions/the-problem#solution) and return its _score_ to the autopilot.
-The score is the quality of the solution, which accounts for surplus and fee paid, and represents what CoW Protocol intends to optimize with the solver competition; it's described in details in the [description of CoW Protocol's optimization problem](/cow-protocol/reference/core/auctions/the-problem).
-The autopilot selects the winner based on this score once the allotted time expires or all solvers have returned their batch proposal.
+Solvers have a short amount time (seconds) to come up with a [solution](/cow-protocol/reference/core/auctions/the-problem#solution) and return its _score_ to the autopilot, which represents the quality of a solution.
+The scoring process is described in detail in the [description of CoW Protocol's optimization problem](/cow-protocol/reference/core/auctions/the-problem).
+The autopilot selects the winner according to the highest score once the allotted time expires or all solvers have returned their batch proposal.
 
 Up to this point, the autopilot only knows the score and not the full solution that achieves that score.
 The autopilot then asks the winning solver to reveal its score (through `/reveal`) and then to execute the corresponding settlement transaction (`/settle`).

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -1,6 +1,150 @@
 ---
 sidebar_position: 2
-draft: true
 ---
 
 # Autopilot
+
+The autopilot is the engine that drives forward CoW Protocol.
+
+Running at a regular interval, it keeps an up-to-date view on the state of the protocol,
+synthesizes this data into an _auction_,
+broadcasts this auction to each of the solvers,
+and finally chooses which solution will be executed.
+
+Users don't interact with the autopilot directly: its only intended interface is with the solvers (through the driver).
+Unlike solvers, there is a single autopilot running for each chain[^barn].
+
+Its role can be broadly summarized into these main purposes.
+
+1. Data collection, which is mainly:
+   - Liquidity gathering
+   - Order information
+2. Cutting auctions
+3. Solver competition
+4. Auction data storage
+
+```mermaid
+sequenceDiagram
+    participant orderbook
+    participant database
+    participant blockchain
+    participant autopilot
+    box external drivers
+      participant driver 1
+      participant driver 2
+      participant driver 3
+    end
+
+    par data retrieval
+      # database orders
+      orderbook->>database: Update database
+    and
+      autopilot->>+database: Get order information
+      database->>-autopilot: Uids, signatures, owners...
+    and
+      autopilot->>+blockchain: Get order information
+      blockchain->>-autopilot: Onchain cancellations, ETH flow...
+    and
+      autopilot->>+blockchain: Get liquidity
+      blockchain->>-autopilot: Uniswap, Balancer, ...
+    end
+
+    # auction
+    Note over autopilot: Cut auction
+    par broadcast current auction
+      autopilot->>driver 1: /solve
+      activate driver 1
+    and
+      autopilot->>driver 2: /solve
+      activate driver 2
+    and
+      autopilot->>driver 3: /solve
+      activate driver 3
+    end
+    driver 3->>autopilot: Proposed batch
+    deactivate driver 3
+    driver 1->>autopilot: Proposed batch
+    deactivate driver 1
+    driver 2->>autopilot: Proposed batch
+    deactivate driver 2
+
+    Note over autopilot: Pick winner
+    autopilot->>+driver 2: /reveal
+    driver 2->>-autopilot: Ethereum transaction data
+    autopilot->>+driver 2: /settle
+    driver 2->>+blockchain: Execute transaction
+    blockchain->>-driver 2: Transaction receipt
+    driver 2->>-autopilot: Transaction hash
+
+    autopilot->>database: Store auction data
+```
+
+[^barn]: There is technically also a second autopilot running on each network for testing purposes (in the _barn_ environment), but this isn't necessary for running the protocol.
+
+## Data collection
+
+The autopilot needs to have a complete overview of the protocol and of many other third-party protocols in order to build an [auction](/cow-protocol/reference/core/auctions/schema) that is as complete as possible.
+
+Much of the order data it needs is collected through the database, which is shared with the orderbook.
+The database stores the vast majority of available order information, including user signatures.
+
+Other information can only be retrieved onchain and is updated every time a new block is mined. For example, it needs to know from the protocol:
+
+- Which [pre-signatures](/cow-protocol/reference/core/signing-schemes#presign) have been set
+- If new [eth-flow orders](/cow-protocol/tutorials/cow-swap/native#eth-flow) have been created
+- Tracking which orders have been [invalidated](/cow-protocol/reference/contracts/core/settlement#invalidateorder) by the user
+- Detecting if a batch has been settled and it should prepare a new auction
+
+Retrieved information isn't limited to the CoW Protocol itself.
+The aution data also contains information on which liquidity is available to the solvers to settle an auction's orders.
+Solvers may use this liquidity information to help them out with finding a solution more quickly.
+Some liquidity sources are also used to provide a reference price of each token in an order;
+the reference price is used to normalize the value of the [surplus](/cow-protocol/reference/core/auctions/the-problem), since the surplus must be comparable for all orders and an order could use the most disparate ERC-20 tokens.
+
+Examples of liquidity sources that are tracked by the autopilot:
+- Uniswap (v2 and v3)
+- Balancer (Weighted, Weighted2Token, ComposableStable, ...)
+- SushiSwap
+- Swapr
+
+## Cutting auctions
+
+The autopilot constantly updates the list of orders that can be settled based on the data retrieved above.
+
+Orders that can't be settled are filtered out: these are expired orders, those with not enough balance, with missing approvals, or that use tokens that aren't supported by the protocol.
+
+The autopilot also checks that [ERC-1271](/cow-protocol/reference/core/signing-schemes#erc-1271) signatures are currently valid.
+
+This steps tries to guarantees that all available orders can be settled on CoW Protocol without further checks from the solvers.
+
+## Solver competition
+
+Once an auction is ready, the autopilot sends a `/solve` request to each solver's driver.
+Solvers have a short amount time (seconds) to come up with a [solution](/cow-protocol/core/auctions/the-problem#solution) and return its _score_ to the autopilot.
+The autopilot selects the winner based on this score once the allotted time expires or all drivers have returned their batch proposal.
+
+Up to this point, the autopilot only knows the score and not the full solution that achieves that score.
+The autopilot then asks the winning solver to reveal its score (throug `/reveal`) and then to execute the corresponding settlement transaction (`/settle`).
+The solver is responsible for executing the transaction onchain (through the driver).
+
+## Auction data storage
+
+The data returned by the solver is stored by the autopilot on the database.
+Other auction data is recorded as well, for example surplus fee for limit orders and the score returned by each solver.
+It also records the result of executing the settlement onchain in order to track the difference in score caused by negative or positive slippage.
+
+This data will be used to compute the [solver payouts](/cow-protocol/reference/core/auctions/rewards).
+## Complexities
+
+A typical challenge in the autopilot is handling block reorgs.
+The autopilot must be able to revert as many actions as possible in case of a reorg; everything that can't be reverted must be accounted for in the stored data.
+
+## What the autopilot doesn't do
+
+The autopilot doesn't verify that a solver's transaction is valid, nor that it matches the score provided by the solver.
+For this purpose, it's only responsible for documenting the proposed solution and the effects of a settlement to the onchain state.
+Misbehavior is detected and accounted for when computing the solver payouts based on the data collected by the autopilot.
+The solver payouts are handled outside of the autopilot code.
+
+In the same way, the autopilot doesn't verify that the [rules of the game](/cow-protocol/reference/core/auctions/social-consensus) have been upheld.
+This is handled in the solver payout stage as well; in exceptional circumstances the DAO can decide to slash the amount the solver staked for vouching.

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -76,7 +76,8 @@ sequenceDiagram
 
 ## Data collection
 
-The autopilot needs to have a complete overview of the protocol and of many other third-party protocols in order to build an [auction](/cow-protocol/reference/core/auctions/schema) that is as complete as possible.
+The autopilot builds an [auction](/cow-protocol/reference/core/auctions/schema) that includes all tradable orders.
+To handle this, it needs to maintain a complete overview of the protocol.
 
 Much of the order data it needs is collected through the database, which is shared with the orderbook.
 The database stores the vast majority of available order information, including user signatures.

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -101,6 +101,9 @@ Orders that can't be settled are filtered out: these are expired orders, those w
 
 The autopilot also checks that [ERC-1271](/cow-protocol/reference/core/signing-schemes#erc-1271) signatures are currently valid.
 
+More in general, the autopilot aims to remove from the auction all orders that have no chance to be settled.
+Still, this doesn't mean that all orders that appear in the auction can be settled: orders whose ability to be settled is ambigous or unclear are remitted to the solvers' own judgment.
+
 ## Solver competition
 
 Once an auction is ready, the autopilot sends a `/solve` request to each solver.

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -104,7 +104,8 @@ The autopilot also checks that [ERC-1271](/cow-protocol/reference/core/signing-s
 ## Solver competition
 
 Once an auction is ready, the autopilot sends a `/solve` request to each solver.
-Solvers have a short amount time (seconds) to come up with a [solution](/cow-protocol/core/auctions/the-problem#solution) and return its _score_ to the autopilot.
+Solvers have a short amount time (seconds) to come up with a [solution](/cow-protocol/reference/core/auctions/the-problem#solution) and return its _score_ to the autopilot.
+The score is the quality of the solution, which accounts for surplus and fee paid, and represents what CoW Protocol intends to optimize with the solver competition; it's described in details in the [description of CoW Protocol's optimization problem](/cow-protocol/reference/core/auctions/the-problem).
 The autopilot selects the winner based on this score once the allotted time expires or all solvers have returned their batch proposal.
 
 Up to this point, the autopilot only knows the score and not the full solution that achieves that score.

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -136,6 +136,8 @@ This data will be used to compute the [solver payouts](/cow-protocol/reference/c
 A typical challenge in the autopilot is handling block reorgs.
 The autopilot must be able to revert as many actions as possible in case of a reorg; everything that can't be reverted must be accounted for in the stored data.
 
+In practice this means that some information (e.g., competition data by transaction hash) is only available after a "reorg safe" threshold of blocks have been proposed.
+
 ## What the autopilot doesn't do
 
 The autopilot doesn't verify that a solver's transaction is valid, nor that it matches the score provided by the solver.

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -117,7 +117,7 @@ The autopilot selects the winner based on this score once the allotted time expi
 
 Up to this point, the autopilot only knows the score and not the full solution that achieves that score.
 The autopilot then asks the winning solver to reveal its score (through `/reveal`) and then to execute the corresponding settlement transaction (`/settle`).
-The solver is responsible for executing the transaction onchain (through the [driver](driver)).
+The solver is responsible for executing the transaction onchain (through the [driver](driver) if using the reference implementation).
 
 ## Auction data storage
 

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -93,9 +93,9 @@ the reference price is used to normalize the value of the [surplus](/cow-protoco
 The reference token is usually the chain's native token, since it's the token used to pay for the gas needed when executing a transaction. 
 Orders whose price can't be fetched are discarded and won't be included in an auction.
 
-Native token price fetching is handled by a integrated price estimator in the autopilot.
+Native token price fetching is handled by an integrated price estimator in the autopilot.
 The price is fetched from multiple sources and may change based on the current configurations.
-Prices are both queried from a list of selected existing solvers as well as retrieved internally to the autopilot (for example, by querying some external parties like Paraswap and 1inch, but also by reading onchain pool data as Uniswap).
+Prices are both queried from a list of selected existing solvers as well as retrieved internally by the autopilot (for example, by querying some external parties like Paraswap and 1inch, but also by reading onchain pool data as Uniswap).
 
 Orders that can't be settled are filtered out: these are expired orders, those with not enough balance, with missing approvals, or that use tokens that aren't supported by the protocol.
 

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -109,12 +109,12 @@ The score is the quality of the solution, which accounts for surplus and fee pai
 The autopilot selects the winner based on this score once the allotted time expires or all solvers have returned their batch proposal.
 
 Up to this point, the autopilot only knows the score and not the full solution that achieves that score.
-The autopilot then asks the winning solver to reveal its score (throug `/reveal`) and then to execute the corresponding settlement transaction (`/settle`).
+The autopilot then asks the winning solver to reveal its score (through `/reveal`) and then to execute the corresponding settlement transaction (`/settle`).
 The solver is responsible for executing the transaction onchain (through the [driver](driver)).
 
 ## Auction data storage
 
-The data returned by the solver is stored by the autopilot on the database.
+The data returned by the solver is stored by the autopilot in the database.
 Other auction data is recorded as well, for example surplus fee for limit orders and the score returned by each solver.
 It also records the result of executing the settlement onchain in order to track the difference in score caused by negative or positive slippage.
 

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -13,12 +13,11 @@ There is a single autopilot running for each chain[^barn].
 
 Its role can be broadly summarized into these main purposes.
 
-1. Data collection, which is mainly:
-   - Liquidity gathering
-   - Order information
-2. Cutting auctions
-3. Solver competition
-4. Auction data storage
+1. Cutting auctions
+   - Data availability consensus around which orders are valid for a given batch
+   - The initial exchange rates for each traded tokens which are used to normalize surplus across different orders
+2. Solver competition
+3. Auction data storage
 
 ```mermaid
 sequenceDiagram
@@ -74,7 +73,7 @@ sequenceDiagram
 
 [^barn]: There is technically also a second autopilot running on each network for testing purposes (in the _barn_ environment), but this isn't necessary for running the protocol.
 
-## Data collection
+## Cutting auctions
 
 The autopilot builds an [auction](/cow-protocol/reference/core/auctions/schema) that includes all tradable orders.
 To handle this, it needs to maintain a complete overview of the protocol.
@@ -100,10 +99,6 @@ Examples of liquidity sources that are tracked by the autopilot:
 - Balancer (Weighted, Weighted2Token, ComposableStable, ...)
 - SushiSwap
 - Swapr
-
-## Cutting auctions
-
-The autopilot constantly updates the list of orders that can be settled based on the data retrieved above.
 
 Orders that can't be settled are filtered out: these are expired orders, those with not enough balance, with missing approvals, or that use tokens that aren't supported by the protocol.
 

--- a/docs/cow-protocol/tutorials/arbitrate/driver.md
+++ b/docs/cow-protocol/tutorials/arbitrate/driver.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 # Driver

--- a/docs/cow-protocol/tutorials/arbitrate/solver-engine.md
+++ b/docs/cow-protocol/tutorials/arbitrate/solver-engine.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 ---
 
 # Solver Engine


### PR DESCRIPTION
# Description

Documents how the autopilot works.

# Changes

- Filled in autopilot page.
- Simplified architecture page (separate `/reveal` and `/settle` is too much information there imho).

## Related Issues

Part of https://github.com/cowprotocol/docs-v2/issues/41.

