### PR TITLE
Fix broken limit orders and broken image in cancelation

### DIFF
--- a/docs/cow-protocol/tutorials/cow-swap/limit.mdx
+++ b/docs/cow-protocol/tutorials/cow-swap/limit.mdx
@@ -63,7 +63,7 @@ After selecting "Cancel order", you will be prompted to confirm this action.
 
 <CancellationOffChainOnChain
     alt="Cancel confirm"
-    src="/img/cowswap/limit_cancel_confirm.png"
+    img={require("/img/cowswap/limit_cancel_confirm.png")}
 />
 
 Cancelling limit orders is free as it's an off-chain transaction. So feel free to place and cancel limit orders as many times as you want! (Alternatively, if you want a limit order to be canceled as quickly as possible, you can choose to do the cancellation on-chain instead.)

--- a/docs/partials/_cancellation_offchain_versus_onchain.mdx
+++ b/docs/partials/_cancellation_offchain_versus_onchain.mdx
@@ -1,3 +1,6 @@
+import Image from "@theme/IdealImage"
+
+
 Cancelling orders off-chain is free and does *not* require a transaction. However, there is a risk that the order is matched between the time you cancel it and the time the cancellation is processed off-chain.
 
 :::note
@@ -11,7 +14,7 @@ However, it is possible that it was already included in the current auction and 
 To proceed with an off-chain cancellation, click "Request cancellation" as shown below.
 
 <>
-    <p><img {...props} /></p>
+    <p><Image {...props} /></p>
 </>
 
 If you do not want to place trust in the API to cancel your order, you may wish to cancel your order via an on-chain cancellation transaction. 


### PR DESCRIPTION
# Description

This PR address some issues with a fixture that were braking limit orders tutorial and and the  cancelation one

# Changes

Limit orders (before)

<img width="1364" alt="Screenshot at Dec 06 15-41-29" src="https://github.com/cowprotocol/docs-v2/assets/2352112/b94f608c-df72-4c9b-810d-49944318ea23">


Limit orders (after)
<img width="1465" alt="Screenshot at Dec 06 15-42-10" src="https://github.com/cowprotocol/docs-v2/assets/2352112/213ec56a-4a29-42c9-b0c8-3d59b97815ab">


Cancelation (before)
<img width="998" alt="Screenshot at Dec 06 15-30-54" src="https://github.com/cowprotocol/docs-v2/assets/2352112/c5879652-f5cc-4911-92c1-a8ef649e9b07">


Cancelation (after)
<img width="1070" alt="image" src="https://github.com/cowprotocol/docs-v2/assets/2352112/ad6c0202-b01d-4da3-b607-bd448e1119b8">

