### PR TITLE
arbitrate/orderbook documentation

### DIFF
--- a/docs/cow-protocol/tutorials/arbitrate/README.mdx
+++ b/docs/cow-protocol/tutorials/arbitrate/README.mdx
@@ -2,19 +2,31 @@
 
 #### The Orderbook
 
-The orderbook is the main entry point of the protocol. Clients can use the Orderbook API to create trades, get quotes for trades, get currently solved auction, etc. When you go to [CoW Swap](https://swap.cow.fi) and create a trade, the web site uses the OrderBook API to add the trade to the database. All the data orderbook use is stored in the database.
+The orderbook is the main entry point of the protocol. 
+Clients can use the Orderbook API to create trades, get quotes for trades, get currently solved auction, etc. 
+When you go to [CoW Swap](https://swap.cow.fi) and create a trade, the web site uses the OrderBook API to add the trade to the database. 
+All the data orderbook use is stored in the database.
 
 #### The Autopilot
 
-The autopilot is a service that drives the core protocol functionalities. It is responsible for creating and arbitrating auctions. It communicates with the driver and decides when the auction is solved and when the solution is revealed and finally settled. Besides that, autopilot is responsible for monitoring the solvers and making sure they behave correctly (and slashing them if they don't).
+The autopilot is a service that drives the core protocol functionalities.
+It is responsible for creating and arbitrating auctions.
+It communicates with the driver and decides when the auction is solved and when the solution is revealed and finally settled.
+Besides that, autopilot is responsible for monitoring the solvers and making sure they behave correctly (and slashing them if they don't).
 
 #### The Driver
 
-The driver is a service that works as a bridge between the autopilot and the solvers. It prepares all the data needed for the solvers to solve the auction and sends it to them. It also receives solutions from solvers and does a postprocessing on them before sending them to the autopilot. Postprocessing includes encoding, simulating, merging and ranking solutions. The best solution is then sent to the autopilot. If chosen as a winner of the auction, the driver is also responsible for sending the solution to the blockchain.
+The driver is a service that works as a bridge between the autopilot and the solvers.
+It prepares all the data needed for the solvers to solve the auction and sends it to them.
+It also receives solutions from solvers and does a postprocessing on them before sending them to the autopilot.
+Postprocessing includes encoding, simulating, merging and ranking solutions.
+The best solution is then sent to the autopilot. 
+If chosen as a winner of the auction, the driver is also responsible for sending the solution to the blockchain.
 
 #### Solvers
 
-Solvers are services that implement different solving algorithms to optimally solve the auction. They are expected to build solutions and return them to the driver before the deadline.
+Solvers are services that implement different solving algorithms to optimally solve the auction.
+They are expected to build solutions and return them to the driver before the deadline.
 
 
 # Arbitrating auctions

--- a/docs/cow-protocol/tutorials/arbitrate/README.mdx
+++ b/docs/cow-protocol/tutorials/arbitrate/README.mdx
@@ -3,9 +3,9 @@
 #### The Orderbook
 
 The orderbook is the main entry point of the protocol. 
-Clients can use the Orderbook API to create trades, get quotes for trades, get currently solved auction, etc. 
+Clients can use the Orderbook API to create trades, get quotes for trades, get the current auction, etc. 
 When you go to [CoW Swap](https://swap.cow.fi) and create a trade, the web site uses the OrderBook API to add the trade to the database. 
-All the data orderbook use is stored in the database.
+All the data the orderbook uses is stored in the database.
 
 #### The Autopilot
 
@@ -26,7 +26,7 @@ If chosen as a winner of the auction, the driver is also responsible for sending
 #### Solvers
 
 Solvers are services that implement different solving algorithms to optimally solve the auction.
-They are expected to build solutions and return them to the driver before the deadline.
+They are expected to build solutions and return them to the driver before a given deadline.
 
 
 # Arbitrating auctions

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 # Autopilot

--- a/docs/cow-protocol/tutorials/arbitrate/driver.md
+++ b/docs/cow-protocol/tutorials/arbitrate/driver.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Driver

--- a/docs/cow-protocol/tutorials/arbitrate/orderbook.md
+++ b/docs/cow-protocol/tutorials/arbitrate/orderbook.md
@@ -21,8 +21,8 @@ sequenceDiagram
     actor User
     participant Orderbook
     participant Solver1
-    activate Orderbook
     User->>Orderbook: POST /quote
+    activate Orderbook
     Orderbook->>SolverN: quote?
     activate SolverN
     Orderbook->>Solver1: quote?
@@ -113,7 +113,7 @@ For this either the trader provided quote id is looked up or a fresh quote is cr
 
 The orderbook synchronizes state with the autopilot via a shared database.
 It communicates with solvers to produce price estimates.
-It uses IPFS to update and fetch [appData](../integrations/order-meta-data-appdata) documents.
+It uses IPFS to update and fetch [appData](../integrations/scripts/order-meta-data-appdata/create-a-meta-data-document) documents.
 It also depends on on-chain state for things like:
 - checking the Trader has sufficient balance/approval to place the order
 - simulate smart contract signatures and hooks

--- a/docs/cow-protocol/tutorials/arbitrate/orderbook.md
+++ b/docs/cow-protocol/tutorials/arbitrate/orderbook.md
@@ -11,12 +11,12 @@ Its implementation can be found [here](https://github.com/cowprotocol/services/t
 ## Overview
 
 By and large the orderbook is a [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) service for the state of the protocol.
-It connects to the database which is shared with the (autopilot)[./autopilot] to insert or update orders and serves information about existing orders as well as previous trades and auctions.
+It connects to the database which is shared with the [autopilot](./autopilot) to insert or update orders and serves information about existing orders as well as previous trades and auctions.
 
 ## Architecture
 
 The standard Trader interaction flow can be seen in the following sequence diagram:
-
+```mermaid
 sequenceDiagram
     actor User
     participant Orderbook
@@ -63,21 +63,21 @@ sequenceDiagram
 
 After selecting the parameters of their trade, most Traders want to see an estimate of how much tokens they will receive in order to pick a reasonable limit price.
 For that they send a `/quote` request to the orderbook. 
-The orderbook is connected to a subset of solvers that are participating in the competitions (technically their (**drivers**)[./driver]) and creates price estimates by sending these solvers a request to solve a batch auction containing just a single order.
+The orderbook is connected to a subset of solvers that are participating in the competitions (technically their [**drivers**](./driver)) and creates price estimates by sending these solvers a request to solve a batch auction containing just a single order.
 
 The orderbook may simulate quotes if possible to make sure their proposed solution would pass given the current state of the chain and picks the one maximizing the traders' output (the solver winning the quote is rewarded by the protocol). 
-The quote is turned into an order that is returned to the Trader and may be signed.
+The quote is turned into an order that is returned to the Trader and is ready to be signed by the user.
 
 Once signed, the trader will post the order for inclusion in the next batch.
 At this stage the orderbook will verify the order is valid and either fetch the existing quote or create a new one (the "expected" out amount at order placement time is relevant for order classification and fee policies).
 Finally it stores the order in the database, so that the autopilot can index it, and returns the uniquer identifier to the trader.
 
-Now it's the protocols and solvers' turn to distribute and match the order.
+Now it's the protocol's and solvers' turn to distribute and match the order.
 During this time, the trader may request status updates about their order from the orderbook and finally request information about the executed trade and solver competition.
 
 ## Methodology (how the component works)
 
-The orderbook exposes a variety of different endpoints 
+The orderbook exposes a variety of different endpoints.
 The majority of them are simple REST interfaces on top of the data model that is stored in the database.
 However, there are some more involved operations, which are worth explaining in more detail:
 
@@ -93,7 +93,7 @@ Optimal quotes wait for all connected solvers to either return a response or tim
 
 Fast quotes return the best estimate as soon as a threshold of solvers (ie. two) have returned a successful estimate.
 
-The API also exposes a `/native_price` route which can be used to get even more indicative estimates (ie for showing approximate dollar or ETH amounts of a trade).
+The API also exposes another price-related route, `/native_price`, which can be used to get an approximate estimate of the dollar (or ETH) value for a given amount of tokens.
 These price estimates use fixed amounts and are more heavily cached allowing for faster response times.
 
 ### Placing orders
@@ -102,17 +102,17 @@ Before an order is accepted in the database it is validated.
 Validation steps include
 - Asserting the order is well formed and all fields are properly encoded
 - The user has sufficient balance/allowance to place this order
-- The signature types is supported and valid
+- The signature type is supported and the signature is valid
 - The pre-image for the order's appData hash is either provided in the request or publicly available on IPFS (to ensure any additional information about the order can be properly interpreted by the orderbook)
 
-Each order is also associated with a quote for classification into in or out of market price (which may have an effect on the fee policy used).
+Each order is also associated with a quote for classification as either in or out of market price. This may have an effect on the fee policy used.
 For this either the trader provided quote id is looked up or a fresh quote is created.
 
 ## Dependencies / interactions
 
 The orderbook synchronizes state with the autopilot via a shared database.
 It communicates with solvers to produce price estimates.
-It uses IPFS to update and fetch (appData)[../integrations/order-meta-data-appdata] documents
+It uses IPFS to update and fetch [appData](../integrations/order-meta-data-appdata) documents.
 It also depends on on-chain state for things like:
 - checking the Trader has sufficient balance/approval to place the order
 - simulate smart contract signatures and hooks

--- a/docs/cow-protocol/tutorials/arbitrate/orderbook.md
+++ b/docs/cow-protocol/tutorials/arbitrate/orderbook.md
@@ -1,0 +1,120 @@
+---
+sidebar_position: 1
+---
+
+# Orderbook
+
+The orderbook is the main API that Traders, UIs and other integrations use to interact with CoW Protocol.
+
+Its implementation can be found [here](https://github.com/cowprotocol/services/tree/main/crates/orderbook). The API is documented in detail [here](../../reference/apis/orderbook). 
+
+## Overview
+
+By and large the orderbook is a [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) service for the state of the protocol.
+It connects to the database which is shared with the (autopilot)[./autopilot] to insert or update orders and serves information about existing orders as well as previous trades and auctions.
+
+## Architecture
+
+The standard Trader interaction flow can be seen in the following sequence diagram:
+
+sequenceDiagram
+    actor User
+    participant Orderbook
+    participant Solver1
+    activate Orderbook
+    User->>Orderbook: POST /quote
+    Orderbook->>SolverN: quote?
+    activate SolverN
+    Orderbook->>Solver1: quote?
+    activate Solver1
+    Solver1->>Solver1: compute matching for<br> "single order batch"
+    SolverN->>SolverN: compute matching for<br> "single order batch"
+    Solver1-->>Orderbook: result
+    deactivate Solver1
+    SolverN-->>Orderbook: result
+    deactivate SolverN
+    Orderbook->>Orderbook: simulate quote
+    Orderbook->>Orderbook: pick best result
+    Orderbook->>Database: store quote
+    Orderbook-->>User: quote
+    deactivate Orderbook
+    User->>User: 🖊 Sign order
+    User->>Orderbook: POST /order
+    activate Orderbook
+    Orderbook->>Orderbook: verify order
+    Orderbook->>Database: fetch quote
+    opt if quote not found
+      Orderbook->>Solver1: quote?
+      Solver1-->>Orderbook: result
+      Orderbook->>SolverN: quote?
+      SolverN-->>Orderbook: result
+      Orderbook->>Orderbook: smualate & pick
+    end
+    Orderbook->>Database: insert order
+    Orderbook-->>User: order UID
+    deactivate Orderbook
+    User->>User: ⏳ Wait for happy moo
+    User->>Orderbook: GET /trades
+    activate Orderbook
+    Orderbook->>Database: lookup order
+    Database-->>Orderbook: order & trades
+    Orderbook-->>User: trades
+    deactivate Orderbook
+
+After selecting the parameters of their trade, most Traders want to see an estimate of how much tokens they will receive in order to pick a reasonable limit price.
+For that they send a `/quote` request to the orderbook. 
+The orderbook is connected to a subset of solvers that are participating in the competitions (technically their (**drivers**)[./driver]) and creates price estimates by sending these solvers a request to solve a batch auction containing just a single order.
+
+The orderbook may simulate quotes if possible to make sure their proposed solution would pass given the current state of the chain and picks the one maximizing the traders' output (the solver winning the quote is rewarded by the protocol). 
+The quote is turned into an order that is returned to the Trader and may be signed.
+
+Once signed, the trader will post the order for inclusion in the next batch.
+At this stage the orderbook will verify the order is valid and either fetch the existing quote or create a new one (the "expected" out amount at order placement time is relevant for order classification and fee policies).
+Finally it stores the order in the database, so that the autopilot can index it, and returns the uniquer identifier to the trader.
+
+Now it's the protocols and solvers' turn to distribute and match the order.
+During this time, the trader may request status updates about their order from the orderbook and finally request information about the executed trade and solver competition.
+
+## Methodology (how the component works)
+
+The orderbook exposes a variety of different endpoints 
+The majority of them are simple REST interfaces on top of the data model that is stored in the database.
+However, there are some more involved operations, which are worth explaining in more detail:
+
+### Getting quotes
+
+The quoting process piggy-backs on the solver competition.
+Solver are tasked in finding a matching for an auction instance including only one order (the order to be quoted).
+These quote auctions have a significantly shorter deadline to solve "quote" auctions as they are fundamentally simpler to solve.
+
+Quotes can be requested using either the "fast" or "optimal" quality type.
+
+Optimal quotes wait for all connected solvers to either return a response or time out before yielding a result.
+
+Fast quotes return the best estimate as soon as a threshold of solvers (ie. two) have returned a successful estimate.
+
+The API also exposes a `/native_price` route which can be used to get even more indicative estimates (ie for showing approximate dollar or ETH amounts of a trade).
+These price estimates use fixed amounts and are more heavily cached allowing for faster response times.
+
+### Placing orders
+
+Before an order is accepted in the database it is validated.
+Validation steps include
+- Asserting the order is well formed and all fields are properly encoded
+- The user has sufficient balance/allowance to place this order
+- The signature types is supported and valid
+- The pre-image for the order's appData hash is either provided in the request or publicly available on IPFS (to ensure any additional information about the order can be properly interpreted by the orderbook)
+
+Each order is also associated with a quote for classification into in or out of market price (which may have an effect on the fee policy used).
+For this either the trader provided quote id is looked up or a fresh quote is created.
+
+## Dependencies / interactions
+
+The orderbook synchronizes state with the autopilot via a shared database.
+It communicates with solvers to produce price estimates.
+It uses IPFS to update and fetch (appData)[../integrations/order-meta-data-appdata] documents
+It also depends on on-chain state for things like:
+- checking the Trader has sufficient balance/approval to place the order
+- simulate smart contract signatures and hooks
+
+

--- a/docs/cow-protocol/tutorials/arbitrate/orderbook.md
+++ b/docs/cow-protocol/tutorials/arbitrate/orderbook.md
@@ -60,6 +60,7 @@ sequenceDiagram
     Database-->>Orderbook: order & trades
     Orderbook-->>User: trades
     deactivate Orderbook
+```
 
 After selecting the parameters of their trade, most Traders want to see an estimate of how much tokens they will receive in order to pick a reasonable limit price.
 For that they send a `/quote` request to the orderbook. 

--- a/docs/cow-protocol/tutorials/arbitrate/solver-engine.md
+++ b/docs/cow-protocol/tutorials/arbitrate/solver-engine.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Solver Engine


### PR DESCRIPTION
# Description

Adds documentation for the fourth main binary of the services, the orderbook.

# Changes

<!-- List of detailed changes (how the change is accomplished) -->

- [ ] Orderbook description in line with the other chapters in this section.
- [ ] One line per sentence in top level arbitrate section

## Related Issues

Fixes #208
