### PR TITLE
Iteration on exisiting arbitrate section

### DIFF
--- a/docs/cow-protocol/tutorials/arbitrate/README.mdx
+++ b/docs/cow-protocol/tutorials/arbitrate/README.mdx
@@ -4,7 +4,7 @@ This section gives a high level overview of the different components that are in
 
 ## Architecture
 
-Four main sub-systems are required to facilitate and drive the auction.
+Three main sub-systems are required to facilitate and drive the auction.
 
 ### The Orderbook
 
@@ -27,9 +27,8 @@ For the sake of this documentation, we differentiate solvers into two sub-parts:
 #### The Driver
 
 This is the executive part of the solving process, responsible for interacting with the blockchain in order to enrich, encode and eventually execute the settlement.
-It prepares all the data needed for the engine to match order in the auction and forwards the augmented auction to the engine.
+It prepares all the data needed for the engine to match orders in the auction and forwards the augmented auction to the engine.
 In turn it receives raw solutions from the solver engine, which it post-processes, simulates, merges, encodes into a blockchain transaction and finally scores.
-Postprocessing includes encoding, simulating, merging and ranking solutions.
 The driver interfaces with the autopilot and reports the best solution's score to participate in the competition.
 If chosen as a winner of the auction, the driver is also responsible for getting the solution included in the blockchain.
 

--- a/docs/cow-protocol/tutorials/arbitrate/README.mdx
+++ b/docs/cow-protocol/tutorials/arbitrate/README.mdx
@@ -1,35 +1,46 @@
-# Architecture
+# Arbitrating auctions
 
-#### The Orderbook
+This section gives a high level overview of the different components that are involved for CoW protocol batch auctions to take place.
 
-The orderbook is the main entry point of the protocol. 
-Clients can use the Orderbook API to create trades, get quotes for trades, get the current auction, etc. 
-When you go to [CoW Swap](https://swap.cow.fi) and create a trade, the web site uses the OrderBook API to add the trade to the database. 
-All the data the orderbook uses is stored in the database.
+## Architecture
 
-#### The Autopilot
+Four main sub-systems are required to facilitate and drive the auction.
+
+### The Orderbook
+
+The orderbook is the main entry point of the protocol for traders.
+UIs and other integrations can use the orderbook's API to create trades, get quotes for trades, get currently solved auction, etc. 
+For instance, when you visit [CoW Swap](https://swap.cow.fi) and place an order, the site uses the OrderBook API to add the order to a database. 
+This database with all order is shared with the **autopilot**.
+
+### The Autopilot
 
 The autopilot is a service that drives the core protocol functionalities.
 It is responsible for creating and arbitrating auctions.
-It communicates with the driver and decides when the auction is solved and when the solution is revealed and finally settled.
-Besides that, autopilot is responsible for monitoring the solvers and making sure they behave correctly (and slashing them if they don't).
+It decides which orders are valid for a specific auction, defines the timeline for each auction and orchestrates the revelation and settlement of the winning solver's solution.
+Besides that, the autopilot monitors the competition and serves as data consensus layer in the case of dispute or slashing by the DAO.
+Auctions are communicated to all registered solvers.
+
+### Solvers 
+For the sake of this documentation, we differentiate solvers into two sub-parts:
 
 #### The Driver
 
-The driver is a service that works as a bridge between the autopilot and the solvers.
-It prepares all the data needed for the solvers to solve the auction and sends it to them.
-It also receives solutions from solvers and does a postprocessing on them before sending them to the autopilot.
+This is the executive part of the solving process, responsible for interacting with the blockchain in order to enrich, encode and eventually execute the settlement.
+It prepares all the data needed for the engine to match order in the auction and forwards the augmented auction to the engine.
+In turn it receives raw solutions from the solver engine, which it post-processes, simulates, merges, encodes into a blockchain transaction and finally scores.
 Postprocessing includes encoding, simulating, merging and ranking solutions.
-The best solution is then sent to the autopilot. 
-If chosen as a winner of the auction, the driver is also responsible for sending the solution to the blockchain.
+The driver interfaces with the autopilot and reports the best solution's score to participate in the competition.
+If chosen as a winner of the auction, the driver is also responsible for getting the solution included in the blockchain.
 
-#### Solvers
+#### Solver Engine
 
-Solvers are services that implement different solving algorithms to optimally solve the auction.
-They are expected to build solutions and return them to the driver before a given deadline.
+Solvers Engines implement the pure matching logic, by employing different types of solving algorithms to optimally match traders with one another taking on-chain as well as private liquidity into account.
+They receive the pre-processed auction instance from the driver sub-component and return the solution together with instructions on how to achieve the fulfillment on-chain.
 
+## Interactions
 
-# Arbitrating auctions
+The main flow of arbitrating an auction end-to-end can be seen in the following sequence diagram:
 
 ```mermaid
 sequenceDiagram

--- a/docs/cow-protocol/tutorials/arbitrate/README.mdx
+++ b/docs/cow-protocol/tutorials/arbitrate/README.mdx
@@ -6,35 +6,47 @@ This section gives a high level overview of the different components that are in
 
 Three main sub-systems are required to facilitate and drive the auction.
 
-### The Orderbook
+### OrderBook
 
-The orderbook is the main entry point of the protocol for traders.
-UIs and other integrations can use the orderbook's API to create trades, get quotes for trades, get currently solved auction, etc. 
+The [orderbook](./arbitrate/orderbook) is the main entry point of the protocol for traders.
+Using the orderbook's API, UIs and other integrations allow traders to:
+
+- Get quotes for orders
+- Place orders
+- Cancel orders
+- Get the currently solved auction, etc.
+
 For instance, when you visit [CoW Swap](https://swap.cow.fi) and place an order, the site uses the OrderBook API to add the order to a database. 
-This database with all order is shared with the **autopilot**.
+This database with all orders is shared with the **autopilot**.
 
-### The Autopilot
+### Autopilot
 
-The autopilot is a service that drives the core protocol functionalities.
-It is responsible for creating and arbitrating auctions.
-It decides which orders are valid for a specific auction, defines the timeline for each auction and orchestrates the revelation and settlement of the winning solver's solution.
-Besides that, the autopilot monitors the competition and serves as data consensus layer in the case of dispute or slashing by the DAO.
-Auctions are communicated to all registered solvers.
+The [autopilot](./arbitrate/autopilot) is a service that drives the core protocol functionalities with responsibilities including:
+
+- Creating and arbitrating auctions
+- Defining the timeline and valid orders for each auction
+- Orchestrating the revelation and settlement of the winning solver's solution
+- Monitoring the competition
+- Serving as data consensus layer in the case of dispute or slashing by the DAO
+- Communicating auctions to all registered solvers
 
 ### Solvers 
 For the sake of this documentation, we differentiate solvers into two sub-parts:
 
-#### The Driver
+#### Driver
 
-This is the executive part of the solving process, responsible for interacting with the blockchain in order to enrich, encode and eventually execute the settlement.
-It prepares all the data needed for the engine to match orders in the auction and forwards the augmented auction to the engine.
-In turn it receives raw solutions from the solver engine, which it post-processes, simulates, merges, encodes into a blockchain transaction and finally scores.
+The [Driver](./arbitrate/solver/driver) is the executive part of the solving process, and is responsible for:
+
+- Interacting with the blockchain in order to enrich, encode and eventually execute the settlement
+- Preparing all the data needed for the engine to match orders in the auction and forwarding the augmented auction to the engine
+- Receiving raw solutions from the solver engine, which it post-processes, simulates, merges, encodes into a blockchain transaction and finally scores
+
 The driver interfaces with the autopilot and reports the best solution's score to participate in the competition.
 If chosen as a winner of the auction, the driver is also responsible for getting the solution included in the blockchain.
 
 #### Solver Engine
 
-Solvers Engines implement the pure matching logic, by employing different types of solving algorithms to optimally match traders with one another taking on-chain as well as private liquidity into account.
+[Solver Engines](./arbitrate/solver/solver-engine) implement the pure matching logic, by employing different types of solving algorithms to optimally match traders with one another taking on-chain as well as private liquidity into account.
 They receive the pre-processed auction instance from the driver sub-component and return the solution together with instructions on how to achieve the fulfillment on-chain.
 
 ## Interactions

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -89,7 +89,7 @@ Other information can only be retrieved onchain and is updated every time a new 
 
 Retrieved information isn't limited to the CoW Protocol itself.
 The autopilot needs to provide a reference price for each token in an order (a numéraire);
-the reference price is used to normalize the value of the [surplus](/cow-protocol/reference/core/auctions/the-problem), since the surplus must be comparable for all orders and an order could use the most disparate ERC-20 tokens.
+the reference price is used to normalize the value of the [surplus](/cow-protocol/reference/core/auctions/the-problem), since the surplus must be comparable for all orders and two orders could use the most disparate ERC-20 tokens.
 The reference token is usually the chain's native token, since it's the token used to pay for the gas needed when executing a transaction. 
 Orders whose price can't be fetched are discarded and won't be included in an auction.
 
@@ -99,14 +99,14 @@ Prices are both queried from a list of selected existing solvers as well as retr
 
 Orders that can't be settled are filtered out. This is the case if, for example:
 * an order is expired
-* the user's balance isn't enough to settle the order
+* for fill-or-kill orders the user's balance isn't enough to settle the order
 * the approval to the vault relayer is missing
 * the involved tokens aren't supported by the protocol
 
 The autopilot also checks that [ERC-1271](/cow-protocol/reference/core/signing-schemes#erc-1271) signatures are currently valid.
 
 More in general, the autopilot aims to remove from the auction all orders that have no chance to be settled.
-Still, this doesn't mean that all orders that appear in the auction can be settled: orders whose ability to be settled is ambigous or unclear are remitted to the solvers' own judgment.
+Still, this doesn't mean that all orders that appear in the auction can be settled: orders whose ability to be settled is ambiguous or unclear are remitted to the solvers' own judgment.
 
 ## Solver competition
 
@@ -126,9 +126,10 @@ Other auction data is recorded as well, for example surplus fee for limit orders
 It also records the result of executing the settlement onchain in order to track the difference in score caused by negative or positive slippage.
 
 This data will be used to compute the [solver payouts](/cow-protocol/reference/core/auctions/rewards).
+
 ## Complexities
 
-A typical challenge in the autopilot is handling block reorgs.
+A typical challenge in the autopilot is handling block (reorgs)[https://www.alchemy.com/overviews/what-is-a-reorg].
 The autopilot must be able to revert as many actions as possible in case of a reorg; everything that can't be reverted must be accounted for in the stored data.
 
 In practice this means that some information (e.g., competition data by transaction hash) is only available after a "reorg safe" threshold of blocks have been proposed.

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -4,7 +4,11 @@ sidebar_position: 2
 
 # Autopilot
 
+## Overview
+
 The autopilot is the engine that drives forward CoW Protocol.
+
+## Architecture
 
 Running at a regular interval, it keeps an up-to-date view on the state of the protocol, synthesizes this data into an _auction_, broadcasts this auction to each of the solvers, and finally chooses which solution will be executed.
 
@@ -13,13 +17,13 @@ There is a single autopilot running for each chain[^barn].
 
 Its role can be broadly summarized into these main purposes.
 
-1. Cutting auctions
+1. [Cutting auctions](#cutting-auctions)
    - Data availability consensus around which orders are valid for a given batch
    - The initial exchange rates for each traded tokens which are used to normalize surplus across different orders
-2. Solver competition
+2. [Solver competition](#solver-competition)
    - Data availability consensus around the available solution candidates and their score
    - Notifying the winning solver to submit their solution
-3. Auction data storage
+3. [Auction data storage](#auction-data-storage)
 
 ```mermaid
 sequenceDiagram
@@ -72,7 +76,9 @@ sequenceDiagram
 
 [^barn]: There is technically also a second autopilot running on each network for testing purposes (in the _barn_ environment), but this isn't necessary for running the protocol.
 
-## Cutting auctions
+## Methodology
+
+### Cutting auctions
 
 The autopilot builds an [auction](/cow-protocol/reference/core/auctions/schema) that includes all tradable orders.
 To handle this, it needs to maintain a complete overview of the protocol.
@@ -108,7 +114,7 @@ The autopilot also checks that [ERC-1271](/cow-protocol/reference/core/signing-s
 More in general, the autopilot aims to remove from the auction all orders that have no chance to be settled.
 Still, this doesn't mean that all orders that appear in the auction can be settled: orders whose ability to be settled is ambiguous or unclear are remitted to the solvers' own judgment.
 
-## Solver competition
+### Solver competition
 
 Once an auction is ready, the autopilot sends a `/solve` request to each solver.
 Solvers have a short amount of time (seconds) to come up with a [solution](/cow-protocol/reference/core/auctions/the-problem#solution) and return its _score_ to the autopilot, which represents the quality of a solution.
@@ -117,9 +123,9 @@ The autopilot selects the winner according to the highest score once the allotte
 
 Up to this point, the autopilot only knows the score and not the full solution that achieves that score.
 The autopilot then asks the winning solver to reveal its score (through `/reveal`) and then to execute the corresponding settlement transaction (`/settle`).
-The solver is responsible for executing the transaction onchain (through the [driver](driver) if using the reference implementation).
+The solver is responsible for executing the transaction onchain (through the [driver](./solver/driver) if using the reference implementation).
 
-## Auction data storage
+### Auction data storage
 
 The data returned by the solver is stored by the autopilot in the database.
 Other auction data is recorded as well, for example surplus fee for limit orders and the score returned by each solver.
@@ -127,19 +133,21 @@ It also records the result of executing the settlement onchain in order to track
 
 This data will be used to compute the [solver payouts](/cow-protocol/reference/core/auctions/rewards).
 
-## Complexities
+## Considerations
 
-A typical challenge in the autopilot is handling block (reorgs)[https://www.alchemy.com/overviews/what-is-a-reorg].
+### Complexities
+
+A typical challenge in the autopilot is handling block [reorgs](https://www.alchemy.com/overviews/what-is-a-reorg).
 The autopilot must be able to revert as many actions as possible in case of a reorg; everything that can't be reverted must be accounted for in the stored data.
 
 In practice this means that some information (e.g., competition data by transaction hash) is only available after a "reorg safe" threshold of blocks have been proposed.
 
-## What the autopilot doesn't do
+### What the autopilot doesn't do
 
 The autopilot doesn't verify that a solver's transaction is valid, nor that it matches the score provided by the solver.
 For this purpose, it's only responsible for documenting the proposed solution and the effects of a settlement to the onchain state.
 Misbehavior is detected and accounted for when computing the solver payouts based on the data collected by the autopilot.
 The solver payouts are handled outside of the autopilot code.
 
-In the same way, the autopilot doesn't verify that the [rules of the game](/cow-protocol/reference/core/auctions/social-consensus) have been upheld.
+In the same way, the autopilot doesn't verify that the [rules of the game](/cow-protocol/reference/core/auctions/competition-rules) have been upheld.
 This is handled in the solver payout stage as well; in exceptional circumstances the DAO can decide to slash the amount the solver staked for vouching.

--- a/docs/cow-protocol/tutorials/arbitrate/orderbook.md
+++ b/docs/cow-protocol/tutorials/arbitrate/orderbook.md
@@ -2,9 +2,9 @@
 sidebar_position: 1
 ---
 
-# Orderbook
+# OrderBook
 
-The orderbook is the main API that Traders, UIs and other integrations use to interact with CoW Protocol.
+The orderbook is the main API that traders, UIs and other integrations use to interact with CoW Protocol.
 
 Its implementation can be found [here](https://github.com/cowprotocol/services/tree/main/crates/orderbook). The API is documented in detail [here](../../reference/apis/orderbook). 
 
@@ -15,59 +15,60 @@ It connects to the database which is shared with the [autopilot](./autopilot) to
 
 ## Architecture
 
-The standard Trader interaction flow can be seen in the following sequence diagram:
+The standard trader interaction flow can be seen in the following sequence diagram:
+
 ```mermaid
 sequenceDiagram
     actor User
-    participant Orderbook
+    participant OrderBook
     participant Solver1
-    User->>Orderbook: POST /quote
-    activate Orderbook
-    Orderbook->>SolverN: quote?
+    User->>OrderBook: POST /quote
+    activate OrderBook
+    OrderBook->>SolverN: quote?
     activate SolverN
-    Orderbook->>Solver1: quote?
+    OrderBook->>Solver1: quote?
     activate Solver1
     Solver1->>Solver1: compute matching for<br> "single order batch"
     SolverN->>SolverN: compute matching for<br> "single order batch"
-    Solver1-->>Orderbook: result
+    Solver1-->>OrderBook: result
     deactivate Solver1
-    SolverN-->>Orderbook: result
+    SolverN-->>OrderBook: result
     deactivate SolverN
-    Orderbook->>Orderbook: simulate quote
-    Orderbook->>Orderbook: pick best result
-    Orderbook->>Database: store quote
-    Orderbook-->>User: quote
-    deactivate Orderbook
+    OrderBook->>OrderBook: simulate quote
+    OrderBook->>OrderBook: pick best result
+    OrderBook->>Database: store quote
+    OrderBook-->>User: quote
+    deactivate OrderBook
     User->>User: 🖊 Sign order
-    User->>Orderbook: POST /order
-    activate Orderbook
-    Orderbook->>Orderbook: verify order
-    Orderbook->>Database: fetch quote
+    User->>OrderBook: POST /order
+    activate OrderBook
+    OrderBook->>OrderBook: verify order
+    OrderBook->>Database: fetch quote
     opt if quote not found
-      Orderbook->>Solver1: quote?
-      Solver1-->>Orderbook: result
-      Orderbook->>SolverN: quote?
-      SolverN-->>Orderbook: result
-      Orderbook->>Orderbook: smualate & pick
+      OrderBook->>Solver1: quote?
+      Solver1-->>OrderBook: result
+      OrderBook->>SolverN: quote?
+      SolverN-->>OrderBook: result
+      OrderBook->>OrderBook: smualate & pick
     end
-    Orderbook->>Database: insert order
-    Orderbook-->>User: order UID
-    deactivate Orderbook
+    OrderBook->>Database: insert order
+    OrderBook-->>User: order UID
+    deactivate OrderBook
     User->>User: ⏳ Wait for happy moo
-    User->>Orderbook: GET /trades
-    activate Orderbook
-    Orderbook->>Database: lookup order
-    Database-->>Orderbook: order & trades
-    Orderbook-->>User: trades
-    deactivate Orderbook
+    User->>OrderBook: GET /trades
+    activate OrderBook
+    OrderBook->>Database: lookup order
+    Database-->>OrderBook: order & trades
+    OrderBook-->>User: trades
+    deactivate OrderBook
 ```
 
-After selecting the parameters of their trade, most Traders want to see an estimate of how much tokens they will receive in order to pick a reasonable limit price.
+After selecting the parameters of their trade, most traders want to see an estimate of how much tokens they will receive in order to pick a reasonable limit price.
 For that they send a `/quote` request to the orderbook. 
 The orderbook is connected to a subset of solvers that are participating in the competitions (technically their [**drivers**](./driver)) and creates price estimates by sending these solvers a request to solve a batch auction containing just a single order.
 
 The orderbook may simulate quotes if possible to make sure their proposed solution would pass given the current state of the chain and picks the one maximizing the traders' output (the solver winning the quote is rewarded by the protocol). 
-The quote is turned into an order that is returned to the Trader and is ready to be signed by the user.
+The quote is turned into an order that is returned to the trader and is ready to be signed by the user.
 
 Once signed, the trader will post the order for inclusion in the next batch.
 At this stage the orderbook will verify the order is valid and either fetch the existing quote or create a new one (the "expected" out amount at order placement time is relevant for order classification and fee policies).
@@ -76,23 +77,22 @@ Finally it stores the order in the database, so that the autopilot can index it,
 Now it's the protocol's and solvers' turn to distribute and match the order.
 During this time, the trader may request status updates about their order from the orderbook and finally request information about the executed trade and solver competition.
 
-## Methodology (how the component works)
+## Methodology
 
 The orderbook exposes a variety of different endpoints.
-The majority of them are simple REST interfaces on top of the data model that is stored in the database.
+The majority of them are simple [REST](https://en.wikipedia.org/wiki/REST) interfaces on top of the data model that is stored in the database.
 However, there are some more involved operations, which are worth explaining in more detail:
 
 ### Getting quotes
 
 The quoting process piggy-backs on the solver competition.
 Solver are tasked in finding a matching for an auction instance including only one order (the order to be quoted).
-These quote auctions have a significantly shorter deadline to solve "quote" auctions as they are fundamentally simpler to solve.
+These quote auctions have a _significantly_ shorter deadline to solve "quote" auctions as they are fundamentally simpler to solve.
 
-Quotes can be requested using either the "fast" or "optimal" quality type.
+Quotes can be requested using either the _fast_ or _optimal_ quality type.
 
-Optimal quotes wait for all connected solvers to either return a response or time out before yielding a result.
-
-Fast quotes return the best estimate as soon as a threshold of solvers (ie. two) have returned a successful estimate.
+- **Optimal quotes**: wait for all connected solvers to either return a response or time out before yielding a result
+- **Fast quotes**: return the best estimate as soon as a threshold of solvers (ie. two) have returned a successful estimate
 
 The API also exposes another price-related route, `/native_price`, which can be used to get an approximate estimate of the dollar (or ETH) value for a given amount of tokens.
 These price estimates use fixed amounts and are more heavily cached allowing for faster response times.
@@ -103,19 +103,19 @@ Before an order is accepted in the database it is validated.
 Validation steps include
 - Asserting the order is well formed and all fields are properly encoded
 - The user has sufficient balance/allowance to place this order
-- The signature type is supported and the signature is valid
-- The pre-image for the order's appData hash is either provided in the request or publicly available on IPFS (to ensure any additional information about the order can be properly interpreted by the orderbook)
+- The [signature type](/cow-protocol/reference/core/signing-schemes) is supported and the signature is valid
+- The pre-image for the order's [appData](/cow-protocol/reference/core/intents/app-data) hash is either provided in the request or publicly available on IPFS (to ensure any additional information about the order can be properly interpreted by the orderbook)
 
 Each order is also associated with a quote for classification as either in or out of market price. This may have an effect on the fee policy used.
-For this either the trader provided quote id is looked up or a fresh quote is created.
+For this either the trader provided `quoteId` is looked up or a fresh quote is created.
 
-## Dependencies / interactions
+## Considerations
 
 The orderbook synchronizes state with the autopilot via a shared database.
 It communicates with solvers to produce price estimates.
-It uses IPFS to update and fetch [appData](../integrations/scripts/order-meta-data-appdata/create-a-meta-data-document) documents.
-It also depends on on-chain state for things like:
-- checking the Trader has sufficient balance/approval to place the order
+It uses IPFS to update and fetch [appData](/cow-protocol/reference/core/intents/app-data) documents.
+It also depends on on-chain state for:
+- checking the trader has sufficient balance/approval to place the order
 - simulate smart contract signatures and hooks
 
 

--- a/docs/cow-protocol/tutorials/arbitrate/solver/_category_.json
+++ b/docs/cow-protocol/tutorials/arbitrate/solver/_category_.json
@@ -1,0 +1,5 @@
+{
+    "label": "Solver",
+    "collapsible": false,
+    "collapsed": false
+}

--- a/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
+++ b/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
@@ -1,12 +1,12 @@
 ---
-sidebar_position: 3
+sidebar_position: 1
 ---
 
 # Driver
 
 People interested in running a solver to participate in CoW Protocol mainly want to focus on implementing the most efficient matching engine.
 However, there are also many mundane tasks that may not seem like a competitive advantage but have to be done regardless.  
-The driver is a plug-and-play component that you can run to take care of these things for you until it makes sense to actually focus on optimizing them yourself.  
+The driver is a plug-and-play component that teams can run to take care of these things until it makes sense for them to actually focus on optimizing them.  
 From the perspective of the protocol a `matching engine` together with its `driver` are considered a `solver`.
 
 ## Overview
@@ -66,7 +66,7 @@ All of these can be individually configured or completely disabled if your match
 #### Postprocessing Solutions
 
 The driver expects the matching engine to return a recipe on how to solve a set of orders but the recipe itself could not be submitted on-chain.
-In the post-processing step the driver applies multiple sanity checks to the solution, encodes it into a transaction that could be executed on-chain and verifies that it actually simulates successfully before it considers the solution valid.
+In the post-processing step the driver applies multiple sanity checks to the solution, encodes it into a transaction that can be executed on-chain and verifies that it actually simulates successfully before it considers the solution valid.
 All this is done because solvers can get slashed for misbehaving so the reference driver checks all it can to reduce the risk of running a solver as much as possible.  
 Since the matching engine is allowed to propose multiple solutions the driver also contains some logic to pick the best one.
 First it will try to merge disjoint solutions to create bigger and more gas efficient batches.
@@ -81,7 +81,7 @@ To protect the solver from losing ETH by submitting solutions that revert the dr
 As soon as it would revert the driver cancels the transaction to cut the losses to a minimum.  
 The driver can be configured to use different submission strategies which it dynamically choses based on the potential of MEV for a settlement.
 If the settlement does not expose any MEV (e.g. it executes all trades without AMMs) it's safe and most efficient to directly submit to the public mempool.
-However, if a settlement exposes MEV the driver would submit to an MEV-protected RPC like `MevBlocker`.
+However, if a settlement exposes MEV the driver would submit to an MEV-protected RPC like [`MEVBlocker`](mevblocker).
 
 ## Methodology
 
@@ -94,8 +94,8 @@ To reconcile these aspects many internal components listen for new blocks gettin
 Whenever that happens the driver fetches all the relevant information and caches it.
 When the next auction comes in and the driver actually needs that data it's already up-to-date and ready to be used.
 
-
 ## Dependencies
 
 The driver only responds to incoming requests sent by the autopilot.
-You can easily set this up locally yourself but for a driver to participate in the competition in CoW Protocol the accompanying solver has to be bonded and registered in the official CoW Protocol off-chain infrastructure.
+You can easily set this up locally yourself but for a driver to participate in the competition in CoW Protocol the accompanying solver has to be bonded and registered in the CoW Protocol off-chain infrastructure.
+For this, please reach out via the [CoW Discord](https://discord.gg/cowprotocol).

--- a/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
+++ b/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
@@ -4,19 +4,22 @@ sidebar_position: 1
 
 # Driver
 
-People interested in running a solver to participate in CoW Protocol mainly want to focus on implementing the most efficient matching engine.
-However, there are also many mundane tasks that may not seem like a competitive advantage but have to be done regardless.  
-The driver is a plug-and-play component that teams can run to take care of these things until it makes sense for them to actually focus on optimizing them.  
-From the perspective of the protocol a `matching engine` together with its `driver` are considered a `solver`.
+People interested in running a solver to participate in CoW Protocol mainly want to focus on implementing the most efficient solver engine.
+However, there are also many mundane tasks that may not seem like a competitive advantage but have to be done regardless.
 
 ## Overview
+
+The driver is a plug-and-play component that teams can run to take care of mundane tasks until it makes sense for them to actually focus on optimizing them.
+From the perspective of the protocol a **solver engine _together_ with its driver** are considered a **solver**.
+
+## Architecture
 
 The open-source Rust implementation can be found in the [driver](https://github.com/cowprotocol/services/tree/main/crates/driver) crate.
 It has a few CLI parameters which can be displayed using `--help` but is mainly configured using a single `.toml` file.
 A documented example file can be found [here](https://github.com/cowprotocol/services/blob/main/crates/driver/example.toml).
 
-The `driver` sits between the [`autopilot`](autopilot) and a [`matching engine`](solver-engine) and acts as a intermediary between the two.
-In case you decide to run the driver for a matching engine the lifecycle of an auction looks like this.
+The `driver` sits between the [autopilot](autopilot) and a [solver engine](solver-engine) and acts as a intermediary between the two.
+In case you decide to run the driver for a solver engine the lifecycle of an auction looks like this.
 
 ```mermaid
 sequenceDiagram
@@ -25,76 +28,78 @@ sequenceDiagram
     end
     box solver
         participant driver
-        participant matching engine
+        participant solver engine
     end
     autopilot->>driver: auction
     driver->>driver: pre-process auction
     driver->>driver: fetch liquidity
-    driver->>matching engine: auction
-    matching engine->>driver: set of solutions
+    driver->>solver engine: auction
+    solver engine-->>driver: set of solutions
     driver->>driver: post-process solutions
-    driver->>autopilot: participate with the best solution
+    driver-->>autopilot: participate with the best solution
     autopilot->>driver: request to reveal details about the settlement,<br>in case this solver won
     autopilot->>driver: request to execute the settlement,<br>in case this solver won
     driver->>driver: execute the settlement
 ```
 
-Splitting the driver from the matching engine is just a design decision to keep the barrier of entry for new solvers low.
+Splitting the driver from the solver engine is just a design decision to keep the barrier of entry for new solvers low.
 However, there is nothing preventing you from patching, forking or reimplementing the driver.
-You can even merge the responsibilities of the driver and matching engine into one if you want to build the most optimal solver possible.  
-The only hard requirement is that the component the autopilot interfaces with implements this [interface](/cow-protocol/reference/apis/driver).
+You can even merge the responsibilities of the driver and solver engine into one if you want to build the most optimal solver possible; the only hard requirement is that the component the autopilot interfaces with implements this [interface](/cow-protocol/reference/apis/driver).
 
-### Responsibilities
+## Methodology
 
-#### Preprocessing Auctions
+### Preprocessing auctions
 
 The auctions sent to the driver by the autopilot only contain the bare minimum of information needed.
-But usually a matching engine requires more information than that so the driver pre-processes the auction before forwarding it to the matching engine.
-We also want to reduce the overall workload of a matching engine, since it's usually expensive to match an order (in terms of time, RPC requests, API calls, etc.).  
+But usually a solver engine requires more information than that so the driver pre-processes the auction before forwarding it to the solver engine.
+We also want to reduce the overall workload of a solver engine, since it's usually expensive to match an order (in terms of time, RPC requests, API calls, etc.).
 That process includes:
 * fetching additional meta data (e.g. token decimals)
 * discarding orders that can definitely not be settled (e.g. user is missing balances)
 * very basic prioritization of remaining orders (e.g. orders below or close to the market price are most likely to settle)
 
-#### Fetching Liquidity
+### Fetching liquidity
 
 Unless you find a perfect CoW you'll need some sort of liquidity to settle an order with.
 To get your solver started with a good set of base liquidity the driver is able to index and encode a broad range of fundamental AMMs.
 These include `UniswapV2` and its derivatives, `UniswapV3` as well as several liquidity sources from the `BalancerV2` family.
-All of these can be individually configured or completely disabled if your matching engine manages liquidity on its own.
+All of these can be individually configured or completely disabled if your solver engine manages liquidity on its own.
 
-#### Postprocessing Solutions
+### Postprocessing solutions
 
-The driver expects the matching engine to return a recipe on how to solve a set of orders but the recipe itself could not be submitted on-chain.
+The driver expects the solver engine to return a recipe on how to solve a set of orders but the recipe itself could not be submitted on-chain.
 In the post-processing step the driver applies multiple sanity checks to the solution, encodes it into a transaction that can be executed on-chain and verifies that it actually simulates successfully before it considers the solution valid.
-All this is done because solvers can get slashed for misbehaving so the reference driver checks all it can to reduce the risk of running a solver as much as possible.  
-Since the matching engine is allowed to propose multiple solutions the driver also contains some logic to pick the best one.
+All this is done because solvers can get slashed for misbehaving so the reference driver checks all it can to reduce the risk of running a solver as much as possible.
+
+Since the solver engine is allowed to propose multiple solutions the driver also contains some logic to pick the best one.
 First it will try to merge disjoint solutions to create bigger and more gas efficient batches.
 Afterwards it will simulate the solutions to get an accurate gas usage for them which is used to compute a score for each one.
 Finally the driver will propose only the highest scoring solution to the autopilot to maximize the solver's chance of winning the auction.
 
-#### Submitting Settlements
+### Submitting settlements
 
-If the solver provided the best solution the autopilot will tell the driver to actually submit it on-chain.
+If a solver provided the best solution the autopilot will tell the driver to actually submit it on-chain.
 This is not as straight forward as it sounds when the blockchain is congested and liquidity sources are volatile.
 To protect the solver from losing ETH by submitting solutions that revert the driver continuously verifies that the solution still works while it submits it on-chain.
-As soon as it would revert the driver cancels the transaction to cut the losses to a minimum.  
+As soon as it would revert the driver cancels the transaction to cut the losses to a minimum.
+
 The driver can be configured to use different submission strategies which it dynamically choses based on the potential of MEV for a settlement.
 If the settlement does not expose any MEV (e.g. it executes all trades without AMMs) it's safe and most efficient to directly submit to the public mempool.
-However, if a settlement exposes MEV the driver would submit to an MEV-protected RPC like [`MEVBlocker`](mevblocker).
+However, if a settlement exposes MEV the driver would submit to an MEV-protected RPC like [MEVBlocker](/mevblocker).
 
-## Methodology
+## Considerations
 
-As you can see the driver has many responsibilities and discussing all of them in detail would be beyond the scope of this documentation but it's worth mentioning one guiding principle that applies to most of them:  
-Make the driver do as little work as possible in the hot path when processing an auction.
+As you can see the driver has many responsibilities and discussing all of them in detail would be beyond the scope of this documentation but it's worth mentioning one guiding principle that applies to most of them: 
+make the driver do as _little_ work as possible in the hot path when processing an auction.
 
 Because having more time for the solver to compute a solution leads to a more competitive solver every process in the driver should introduce as little latency as possible.
-Also the blockchain is obviously the single source of truth for a lot of the state in the driver and fetching state from the network can be quite slow.  
+Also the blockchain is obviously the single source of truth for a lot of the state in the driver and fetching state from the network can be quite slow.
+
 To reconcile these aspects many internal components listen for new blocks getting appended to the blockchain.
 Whenever that happens the driver fetches all the relevant information and caches it.
 When the next auction comes in and the driver actually needs that data it's already up-to-date and ready to be used.
 
-## Dependencies
+### Dependencies
 
 The driver only responds to incoming requests sent by the autopilot.
 You can easily set this up locally yourself but for a driver to participate in the competition in CoW Protocol the accompanying solver has to be bonded and registered in the CoW Protocol off-chain infrastructure.

--- a/docs/cow-protocol/tutorials/arbitrate/solver/solver-engine.md
+++ b/docs/cow-protocol/tutorials/arbitrate/solver/solver-engine.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 2
 ---
 
 # Solver Engine

--- a/docs/cow-protocol/tutorials/arbitrate/solver/solver-engine.md
+++ b/docs/cow-protocol/tutorials/arbitrate/solver/solver-engine.md
@@ -91,7 +91,7 @@ In the case of a perfect CoW, when excess demand and supply are zero, the curren
 
 The naive solver is currently not capable of matching partially fillable orders.
 
-## Dependencies / interactions
+## Dependencies
 
 Solver engines need to be "registered" inside the driver configuration file to receive requests.
 Check `driver::infra::config::file::SolverConfig` for the available configuration parameters.


### PR DESCRIPTION
# Description

Another pass over the existing sections to make them sound a bit more a like. Main focus was on the first section as this one was still referencing the driver and solver in inconsistent ways

# Changes

- [x] Move driver/solver engine chapters into a solver subfolder (to make the structure reflect the fact that solver is one component consisting of two subcomponents).
- [x] Rewrite top level summary to reflect solver = driver + engine logic
- [x] Small iterations to make the whole text sound more like written from one voice

<!--
## Related Issues

Fixes #
-->
