### PR TITLE
Remove reference to Ledger from Hardware wallets

### DIFF
--- a/docs/cow-protocol/tutorials/cow-swap/README.mdx
+++ b/docs/cow-protocol/tutorials/cow-swap/README.mdx
@@ -13,7 +13,7 @@ CoW Swap supports many popular wallets including:
 - Injected wallets, such as [Rabby](https://rabby.io), [MetaMask](https://metamask.io), [Trust Wallet](https://trustwallet.com). In general any wallet implementing [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193)
 - Multisigs wallets such as [Safe](https://safe.global), both as a [Safe app](https://app.safe.global/share/safe-app?appUrl=https%3A%2F%2Fswap.cow.fi&chain=eth), or using Wallet Connect (IOS, Android and Web).
 - Any wallet supporting [WalletConnect v2](https://walletconnect.com) such as most mobile wallets.
-- Hardware wallets such as [Trezor](https://trezor.io), [Ledger](https://www.ledger.com), either directly, or through integration with injected wallets such us Rabby or Metamask.
+- Hardware wallets such as [Trezor](https://trezor.io), either directly, or through integration with injected wallets such us Rabby or Metamask.
 
 If you've developed a wallet that supports [`EIP-712`](https://eips.ethereum.org/EIPS/eip-712) or [`ERC-1271`](https://eips.ethereum.org/EIPS/eip-1271) signing, and would like to have your wallet supported by CoW Swap, please [file an issue](https://github.com/cowprotocol/cowswap/issues/new) or reach out to us on [Discord](https://discord.com/invite/cowprotocol). 
 


### PR DESCRIPTION
Ledger no longer available as direct connection.

Given the lack of trust, and the fact that we do have another HW in the UI, let's just remove the Ledger mention.

# Description

We mention Ledger as a supported HW wallet directly
![image](https://github.com/cowprotocol/docs-v2/assets/43217/6c1de9bc-ab17-49b1-8495-9b01e212055d)

But it has been very recently been removed https://github.com/cowprotocol/cowswap/releases/tag/v1.51.2

It is still supported via 3rd party wallets such as Metamask, but it's no longer possible to connect it directly.

# Changes

- [x] Remove the Ledger reference