### PR TITLE
Added notes on eth-flow

### DIFF
--- a/docs/cow-protocol/tutorials/cow-swap/native.mdx
+++ b/docs/cow-protocol/tutorials/cow-swap/native.mdx
@@ -89,7 +89,7 @@ The refund can be triggered by any account and should happen automatically if yo
 
 :::note
 
-The [Eth-flow](/cow-protocol/reference/contracts/periphery/eth-flow) option is NOT available for Smart Contract wallets.
+The [Eth-flow](/cow-protocol/reference/contracts/periphery/eth-flow) option is NOT available for Smart Contract wallets **in CoW Swap**.
 
 :::
 

--- a/docs/cow-protocol/tutorials/cow-swap/native.mdx
+++ b/docs/cow-protocol/tutorials/cow-swap/native.mdx
@@ -86,3 +86,15 @@ Fear not! If the order fails, your ETH can be refunded into your account.
 The refund can be triggered by any account and should happen automatically if you used the CoW Swap UI. If not, get in touch with us for help at [info@cow.fi](mailto:info@cow.fi)!
 
 :::
+
+:::note
+
+The [Eth-flow](/cow-protocol/reference/contracts/periphery/eth-flow) option is NOT available for Smart Contract wallets.
+
+:::
+
+:::note
+
+The [Eth-flow](/cow-protocol/reference/contracts/periphery/eth-flow) option is ONLY available for [Swaps](/cow-protocol/tutorials/cow-swap/swap).
+
+:::


### PR DESCRIPTION
Ethflow is only available on SWAP and does not support smart contract wallets. Added 2 notes to make that clear.

# Description

There was no clear indication on 2 important aspects of Eth-flow

![image](https://github.com/cowprotocol/docs-v2/assets/43217/5f149b47-8950-45d2-aafa-7762c7482096)

# Changes

- [X] Added note about no support for SC wallets
- [X] Added note about eth-flow only working on SWAP