### PR TITLE
Fix sidebar position in solvers tutorial section

### DIFF
--- a/docs/cow-protocol/tutorials/solvers/workshop.md
+++ b/docs/cow-protocol/tutorials/solvers/workshop.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 draft: true
 ---
 


### PR DESCRIPTION
Position has already been used (see [here](https://github.com/cowprotocol/docs/blob/2d933f006061e5bf460fe3e24b72fc43f0ccff43/docs/cow-protocol/tutorials/solvers/from_shadow_to_prod.md?plain=1#L2)), and i am wondering if this is the reason causing issue #285
