### PR TITLE
chore: bump docusaurus to 3.2.1

### DIFF
--- a/docs/cow-protocol/reference/contracts/core/vault_relayer.md
+++ b/docs/cow-protocol/reference/contracts/core/vault_relayer.md
@@ -15,7 +15,7 @@ The `GPv2VaultRelayer` contract is an important component used to protect user f
 
 The `GPv2VaultRelayer` has access to user balances through 3 mechanisms:
 
-1. [Fallback `ERC-20` Allowances](#fallback-erc20-allowances)
+1. [Fallback `ERC-20` Allowances](#fallback-erc-20-allowances)
 2. [Balancer External Balances](#balancer-external-balances)
 3. [Balancer Internal Balances](#balancer-internal-balances)
 

--- a/docs/cow-protocol/reference/contracts/periphery/composable_cow.md
+++ b/docs/cow-protocol/reference/contracts/periphery/composable_cow.md
@@ -197,7 +197,7 @@ function verify(
 |---|---|
 | `order` | Proposed discrete order |
 | `ctx` | [Execution context](#execution-context) |
-| `params` | [`ConditionalOrderParams`](#conditionalorderparams-struct) |
+| `params` | [`ConditionalOrderParams`](#conditionalorderparams) |
 | `offchainInput` | Conditional order type-specific data **NOT** known at time of creation for a **specific** discrete order (or zero-length bytes if not applicable) |
 
 ### Guarantees and Invariants
@@ -267,7 +267,7 @@ struct PayloadStruct {
 | **Field** | **Description** |
 |---|---|
 | `proof` | Merkle Tree proof (if applicable, zero length otherwise) |
-| `params` | [`ConditionalOrderParams`](#conditionalorderparams-struct) |
+| `params` | [`ConditionalOrderParams`](#conditionalorderparams) |
 | `offchainInput` | Off-chain input (if applicable, zero length otherwise) |
 
 By setting `proof` to zero-length, this indicates to `ComposableCoW` that the order is a single order, and not part of a Merkle Tree.
@@ -448,7 +448,7 @@ function createWithContext(
 
 | **Parameter** | **Description** |
 |---|---|
-| `params` | [`ConditionalOrderParams`](#conditionalorderparams-struct) |
+| `params` | [`ConditionalOrderParams`](#conditionalorderparams) |
 | `factory` | An `IValueFactory` that will be used to populate the `ctx` storage slot (if applicable) |
 | `data` | Data to be passed to the `factory` to populate the `ctx` storage slot (if applicable) |
 | `dispatch` | If `true`, broadcast the `ConditionalOrderCreated` event |

--- a/docs/cow-protocol/reference/core/intents/README.mdx
+++ b/docs/cow-protocol/reference/core/intents/README.mdx
@@ -7,7 +7,7 @@ Within CoW Protocol, intents are the way that a user expresses their desired swa
 The parameters required for an intent can be broken down into three categories:
 
 * [Batch auction](#batch-auction) parameters - those required to solve the [batch-optimization problem](auctions/the-problem)
-* [Co-ordination / Settlement](#co-ordination-settlement) parameters - those required for co-ordination and settlement purposes
+* [Co-ordination / Settlement](#co-ordination--settlement) parameters - those required for co-ordination and settlement purposes
 * [Metadata](#metadata) parameters - those required for metadata purposes
 
 ### Batch auction

--- a/docs/cow-protocol/tutorials/solvers/cow-amm.md
+++ b/docs/cow-protocol/tutorials/solvers/cow-amm.md
@@ -22,7 +22,7 @@ The order owner is a CoW AMM if its [handler](/cow-protocol/reference/contracts/
 Official deployment addresses for the contracts in this repo can be found in the file [`networks.json`](https://github.com/cowprotocol/cow-amm/blob/3689d24667447ac4882c8bd5d4cbce93ef8a1e86/networks.json).
 
 The field `staticInput` represents the parameters of the AMM, as for example the traded tokens.
-A description of each parameter can be found in the [instructions on how to create an order](#constantproduct-static-input).
+A description of each parameter can be found in the [instructions on how to create an order](/cow-protocol/reference/contracts/programmatic/cow-amm#constantproduct-static-input).
 
 The AMM reserves are the owner's balance of the two tokens traded by the AMM.
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -23,6 +23,7 @@ const config: Config = {
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',
+  onBrokenAnchors: 'throw',
 
   trailingSlash: false,
 

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "fmt": "prettier --write \"**/*.md\""
   },
   "dependencies": {
-    "@docusaurus/core": "^3.1.0",
-    "@docusaurus/plugin-google-gtag": "^3.1.0",
-    "@docusaurus/plugin-ideal-image": "^3.1.0",
-    "@docusaurus/preset-classic": "^3.1.0",
-    "@docusaurus/remark-plugin-npm2yarn": "^3.1.0",
-    "@docusaurus/theme-live-codeblock": "^3.1.0",
-    "@docusaurus/theme-mermaid": "^3.1.0",
+    "@docusaurus/core": "^3.2.1",
+    "@docusaurus/plugin-google-gtag": "^3.2.1",
+    "@docusaurus/plugin-ideal-image": "^3.2.1",
+    "@docusaurus/preset-classic": "^3.2.1",
+    "@docusaurus/remark-plugin-npm2yarn": "^3.2.1",
+    "@docusaurus/theme-live-codeblock": "^3.2.1",
+    "@docusaurus/theme-mermaid": "^3.2.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "docusaurus-json-schema-plugin": "^1.7.0",
@@ -40,9 +40,9 @@
     "swagger-ui-react": "4.15.5"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.0.1",
-    "@docusaurus/tsconfig": "3.0.1",
-    "@docusaurus/types": "3.0.1",
+    "@docusaurus/module-type-aliases": "3.2.1",
+    "@docusaurus/tsconfig": "3.2.1",
+    "@docusaurus/types": "3.2.1",
     "@types/react": "^18.0.0",
     "docusaurus-plugin-typedoc": "^0.21.0",
     "dotenv": "^16.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,7 +388,7 @@
     chalk "^2.4.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.22.15", "@babel/parser@^7.22.7", "@babel/parser@^7.23.5":
+"@babel/parser@^7.22.15", "@babel/parser@^7.23.5":
   version "7.23.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.5.tgz#37dee97c4752af148e1d38c34b856b2507660563"
   integrity sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==
@@ -1220,10 +1220,10 @@
     "@docsearch/css" "3.5.2"
     algoliasearch "^4.19.1"
 
-"@docusaurus/core@3.1.0", "@docusaurus/core@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-3.1.0.tgz#b66e7eaf867c1f44738d725d217a1c0e879629d7"
-  integrity sha512-GWudMGYA9v26ssbAWJNfgeDZk+lrudUTclLPRsmxiknEBk7UMp7Rglonhqbsf3IKHOyHkMU4Fr5jFyg5SBx9jQ==
+"@docusaurus/core@3.2.1", "@docusaurus/core@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-3.2.1.tgz#e9216f9f642b2139541e21f9eebbdb11e12f66da"
+  integrity sha512-ZeMAqNvy0eBv2dThEeMuNzzuu+4thqMQakhxsgT5s02A8LqRcdkg+rbcnuNqUIpekQ4GRx3+M5nj0ODJhBXo9w==
   dependencies:
     "@babel/core" "^7.23.3"
     "@babel/generator" "^7.23.3"
@@ -1235,14 +1235,13 @@
     "@babel/runtime" "^7.22.6"
     "@babel/runtime-corejs3" "^7.22.6"
     "@babel/traverse" "^7.22.8"
-    "@docusaurus/cssnano-preset" "3.1.0"
-    "@docusaurus/logger" "3.1.0"
-    "@docusaurus/mdx-loader" "3.1.0"
+    "@docusaurus/cssnano-preset" "3.2.1"
+    "@docusaurus/logger" "3.2.1"
+    "@docusaurus/mdx-loader" "3.2.1"
     "@docusaurus/react-loadable" "5.5.2"
-    "@docusaurus/utils" "3.1.0"
-    "@docusaurus/utils-common" "3.1.0"
-    "@docusaurus/utils-validation" "3.1.0"
-    "@slorber/static-site-generator-webpack-plugin" "^4.0.7"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-common" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     "@svgr/webpack" "^6.5.1"
     autoprefixer "^10.4.14"
     babel-loader "^9.1.3"
@@ -1263,6 +1262,7 @@
     detect-port "^1.5.1"
     escape-html "^1.0.3"
     eta "^2.2.0"
+    eval "^0.1.8"
     file-loader "^6.2.0"
     fs-extra "^11.1.1"
     html-minifier-terser "^7.2.0"
@@ -1271,6 +1271,7 @@
     leven "^3.1.0"
     lodash "^4.17.21"
     mini-css-extract-plugin "^2.7.6"
+    p-map "^4.0.0"
     postcss "^8.4.26"
     postcss-loader "^7.3.3"
     prompts "^2.4.2"
@@ -1295,45 +1296,43 @@
     webpack-merge "^5.9.0"
     webpackbar "^5.0.2"
 
-"@docusaurus/cssnano-preset@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-3.1.0.tgz#b3fe7134cc4d0c1950eeb1c940089a190591ad4e"
-  integrity sha512-ned7qsgCqSv/e7KyugFNroAfiszuxLwnvMW7gmT2Ywxb/Nyt61yIw7KHyAZCMKglOalrqnYA4gMhLUCK/mVePA==
+"@docusaurus/cssnano-preset@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-3.2.1.tgz#b36041004e837574d0147fcc4932210cdb1efbc1"
+  integrity sha512-wTL9KuSSbMJjKrfu385HZEzAoamUsbKqwscAQByZw4k6Ja/RWpqgVvt/CbAC+aYEH6inLzOt+MjuRwMOrD3VBA==
   dependencies:
     cssnano-preset-advanced "^5.3.10"
     postcss "^8.4.26"
     postcss-sort-media-queries "^4.4.1"
     tslib "^2.6.0"
 
-"@docusaurus/logger@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/logger/-/logger-3.1.0.tgz#eef6475c2d59a3ae7e138ac1f60007d6fafd76b0"
-  integrity sha512-p740M+HCst1VnKKzL60Hru9xfG4EUYJDarjlEC4hHeBy9+afPmY3BNPoSHx9/8zxuYfUlv/psf7I9NvRVdmdvg==
+"@docusaurus/logger@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/logger/-/logger-3.2.1.tgz#6032e421b0b40a2379a3973dcd230d1be49afaa1"
+  integrity sha512-0voOKJCn9RaM3np6soqEfo7SsVvf2C+CDTWhW+H/1AyBhybASpExtDEz+7ECck9TwPzFQ5tt+I3zVugUJbJWDg==
   dependencies:
     chalk "^4.1.2"
     tslib "^2.6.0"
 
-"@docusaurus/lqip-loader@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/lqip-loader/-/lqip-loader-3.1.0.tgz#3a50b0885e4a9058ad775fa573eeca8b8b313496"
-  integrity sha512-vP7Smz7p5Xu75UvD4dA5qlkC7PnXl9dbTv6Eq0kLY8M5ZwBoKhNdB5c8u6j3MS5N8jUTtwYFEuH2wZWjr1/Fpw==
+"@docusaurus/lqip-loader@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/lqip-loader/-/lqip-loader-3.2.1.tgz#183a233c1122f5aa7e75827ce8e25eb752828f8b"
+  integrity sha512-uE4OFsQTs7bwlRAPGaYis+ChI0as/XueC76A8dPbXajUC5f+uYQ1TlxM+NnAfN7dxgtl5OYsciUI/oYIXtob/Q==
   dependencies:
-    "@docusaurus/logger" "3.1.0"
+    "@docusaurus/logger" "3.2.1"
     file-loader "^6.2.0"
     lodash "^4.17.21"
     sharp "^0.32.3"
     tslib "^2.6.0"
 
-"@docusaurus/mdx-loader@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-3.1.0.tgz#61d562ff442f62ef04cc31d3f0d5865a8dd390e4"
-  integrity sha512-D7onDz/3mgBonexWoQXPw3V2E5Bc4+jYRf9gGUUK+KoQwU8xMDaDkUUfsr7t6UBa/xox9p5+/3zwLuXOYMzGSg==
+"@docusaurus/mdx-loader@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-3.2.1.tgz#bea07d47300a158537bc81553769acf72c91c6c3"
+  integrity sha512-Fs8tXhXKZjNkdGaOy1xSLXSwfjCMT73J3Zfrju2U16uGedRFRjgK0ojpK5tiC7TnunsL3tOFgp1BSMBRflX9gw==
   dependencies:
-    "@babel/parser" "^7.22.7"
-    "@babel/traverse" "^7.22.8"
-    "@docusaurus/logger" "3.1.0"
-    "@docusaurus/utils" "3.1.0"
-    "@docusaurus/utils-validation" "3.1.0"
+    "@docusaurus/logger" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     "@mdx-js/mdx" "^3.0.0"
     "@slorber/remark-comment" "^1.0.0"
     escape-html "^1.0.3"
@@ -1356,13 +1355,13 @@
     vfile "^6.0.1"
     webpack "^5.88.1"
 
-"@docusaurus/module-type-aliases@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-3.0.1.tgz#d45990fe377d7ffaa68841cf89401188a5d65293"
-  integrity sha512-DEHpeqUDsLynl3AhQQiO7AbC7/z/lBra34jTcdYuvp9eGm01pfH1wTVq8YqWZq6Jyx0BgcVl/VJqtE9StRd9Ag==
+"@docusaurus/module-type-aliases@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-3.2.1.tgz#fa8fd746890825b4301db2ddbe29d7cfbeee0380"
+  integrity sha512-FyViV5TqhL1vsM7eh29nJ5NtbRE6Ra6LP1PDcPvhwPSlA7eiWGRKAn3jWwMUcmjkos5SYY+sr0/feCdbM3eQHQ==
   dependencies:
     "@docusaurus/react-loadable" "5.5.2"
-    "@docusaurus/types" "3.0.1"
+    "@docusaurus/types" "3.2.1"
     "@types/history" "^4.7.11"
     "@types/react" "*"
     "@types/react-router-config" "*"
@@ -1370,32 +1369,18 @@
     react-helmet-async "*"
     react-loadable "npm:@docusaurus/react-loadable@5.5.2"
 
-"@docusaurus/module-type-aliases@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-3.1.0.tgz#f3451702f143557bfde0502287713a08086a0415"
-  integrity sha512-XUl7Z4PWlKg4l6KF05JQ3iDHQxnPxbQUqTNKvviHyuHdlalOFv6qeDAm7IbzyQPJD5VA6y4dpRbTWSqP9ClwPg==
+"@docusaurus/plugin-content-blog@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.2.1.tgz#1b28c45102abc4be1a57caba76672c5ccdacce63"
+  integrity sha512-lOx0JfhlGZoZu6pEJfeEpSISZR5dQbJGGvb42IP13G5YThNHhG9R9uoWuo4IOimPqBC7sHThdLA3VLevk61Fsw==
   dependencies:
-    "@docusaurus/react-loadable" "5.5.2"
-    "@docusaurus/types" "3.1.0"
-    "@types/history" "^4.7.11"
-    "@types/react" "*"
-    "@types/react-router-config" "*"
-    "@types/react-router-dom" "*"
-    react-helmet-async "*"
-    react-loadable "npm:@docusaurus/react-loadable@5.5.2"
-
-"@docusaurus/plugin-content-blog@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.1.0.tgz#d2102e9286486e526dbc0dfc741e53dc5cee0ff0"
-  integrity sha512-iMa6WBaaEdYuxckvJtLcq/HQdlA4oEbCXf/OFfsYJCCULcDX7GDZpKxLF3X1fLsax3sSm5bmsU+CA0WD+R1g3A==
-  dependencies:
-    "@docusaurus/core" "3.1.0"
-    "@docusaurus/logger" "3.1.0"
-    "@docusaurus/mdx-loader" "3.1.0"
-    "@docusaurus/types" "3.1.0"
-    "@docusaurus/utils" "3.1.0"
-    "@docusaurus/utils-common" "3.1.0"
-    "@docusaurus/utils-validation" "3.1.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/logger" "3.2.1"
+    "@docusaurus/mdx-loader" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-common" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     cheerio "^1.0.0-rc.12"
     feed "^4.2.2"
     fs-extra "^11.1.1"
@@ -1407,18 +1392,19 @@
     utility-types "^3.10.0"
     webpack "^5.88.1"
 
-"@docusaurus/plugin-content-docs@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.1.0.tgz#55d7bdb8e14f854ea6c6e256f1b51b8c17963c19"
-  integrity sha512-el5GxhT8BLrsWD0qGa8Rq+Ttb/Ni6V3DGT2oAPio0qcs/mUAxeyXEAmihkvmLCnAgp6xD27Ce7dISZ5c6BXeqA==
+"@docusaurus/plugin-content-docs@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.2.1.tgz#d3a36239aa11392b0fbed2eaea105c17f64f50ef"
+  integrity sha512-GHe5b/lCskAR8QVbfWAfPAApvRZgqk7FN3sOHgjCtjzQACZxkHmq6QqyqZ8Jp45V7lVck4wt2Xw2IzBJ7Cz3bA==
   dependencies:
-    "@docusaurus/core" "3.1.0"
-    "@docusaurus/logger" "3.1.0"
-    "@docusaurus/mdx-loader" "3.1.0"
-    "@docusaurus/module-type-aliases" "3.1.0"
-    "@docusaurus/types" "3.1.0"
-    "@docusaurus/utils" "3.1.0"
-    "@docusaurus/utils-validation" "3.1.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/logger" "3.2.1"
+    "@docusaurus/mdx-loader" "3.2.1"
+    "@docusaurus/module-type-aliases" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-common" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     "@types/react-router-config" "^5.0.7"
     combine-promises "^1.1.0"
     fs-extra "^11.1.1"
@@ -1428,113 +1414,113 @@
     utility-types "^3.10.0"
     webpack "^5.88.1"
 
-"@docusaurus/plugin-content-pages@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.1.0.tgz#cdb73c804ded307e81ceea39874dc0bb540c2dc4"
-  integrity sha512-9gntYQFpk+93+Xl7gYczJu8I9uWoyRLnRwS0+NUFcs9iZtHKsdqKWPRrONC9elfN3wJ9ORwTbcVzsTiB8jvYlg==
+"@docusaurus/plugin-content-pages@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.2.1.tgz#7e04c470958147ec8bf72c05d3608f1bb8307aab"
+  integrity sha512-TOqVfMVTAHqWNEGM94Drz+PUpHDbwFy6ucHFgyTx9zJY7wPNSG5EN+rd/mU7OvAi26qpOn2o9xTdUmb28QLjEQ==
   dependencies:
-    "@docusaurus/core" "3.1.0"
-    "@docusaurus/mdx-loader" "3.1.0"
-    "@docusaurus/types" "3.1.0"
-    "@docusaurus/utils" "3.1.0"
-    "@docusaurus/utils-validation" "3.1.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/mdx-loader" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     fs-extra "^11.1.1"
     tslib "^2.6.0"
     webpack "^5.88.1"
 
-"@docusaurus/plugin-debug@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-3.1.0.tgz#545872bc8f9cd697d9f1d6c695f8a1674bfc149c"
-  integrity sha512-AbvJwCVRbmQ8w9d8QXbF4Iq/ui0bjPZNYFIhtducGFnm2YQRN1mraK8mCEQb0Aq0T8SqRRvSfC/far4n/s531w==
+"@docusaurus/plugin-debug@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-3.2.1.tgz#59918ac654cbf0f7cf48d43fb9d944296d440784"
+  integrity sha512-AMKq8NuUKf2sRpN1m/sIbqbRbnmk+rSA+8mNU1LNxEl9BW9F/Gng8m9HKlzeyMPrf5XidzS1jqkuTLDJ6KIrFw==
   dependencies:
-    "@docusaurus/core" "3.1.0"
-    "@docusaurus/types" "3.1.0"
-    "@docusaurus/utils" "3.1.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
     fs-extra "^11.1.1"
     react-json-view-lite "^1.2.0"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-google-analytics@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.1.0.tgz#3035eace3121db16aec7c10852ebb4cd860f4434"
-  integrity sha512-zvUOMzu9Uhz0ciqnSbtnp/5i1zEYlzarQrOXG90P3Is3efQI43p2YLW/rzSGdLb5MfQo2HvKT6Q5+tioMO045Q==
+"@docusaurus/plugin-google-analytics@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.2.1.tgz#6cab8df9218b016ce508ff96dd39cf9c87cdc9e5"
+  integrity sha512-/rJ+9u+Px0eTCiF4TNcNtj3kHf8cp6K1HCwOTdbsSlz6Xn21syZYcy+f1VM9wF6HrvUkXUcbM5TDCvg2IRL6bQ==
   dependencies:
-    "@docusaurus/core" "3.1.0"
-    "@docusaurus/types" "3.1.0"
-    "@docusaurus/utils-validation" "3.1.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-google-gtag@3.1.0", "@docusaurus/plugin-google-gtag@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.1.0.tgz#2f4040da81d36bfc6324abc1a12b258e6c7f202a"
-  integrity sha512-0txshvaY8qIBdkk2UATdVcfiCLGq3KAUfuRQD2cRNgO39iIf4/ihQxH9NXcRTwKs4Q5d9yYHoix3xT6pFuEYOg==
+"@docusaurus/plugin-google-gtag@3.2.1", "@docusaurus/plugin-google-gtag@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.2.1.tgz#b54e6bfa0ca2efac5ed02fea39cbf069d2893a2c"
+  integrity sha512-XtuJnlMvYfppeVdUyKiDIJAa/gTJKCQU92z8CLZZ9ibJdgVjFOLS10s0hIC0eL5z0U2u2loJz2rZ63HOkNHbBA==
   dependencies:
-    "@docusaurus/core" "3.1.0"
-    "@docusaurus/types" "3.1.0"
-    "@docusaurus/utils-validation" "3.1.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     "@types/gtag.js" "^0.0.12"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-google-tag-manager@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.1.0.tgz#4c026e9f65468a332326770f95ccd9c6e12d564b"
-  integrity sha512-zOWPEi8kMyyPtwG0vhyXrdbLs8fIZmY5vlbi9lUU+v8VsroO5iHmfR2V3SMsrsfOanw5oV/ciWqbxezY00qEZg==
+"@docusaurus/plugin-google-tag-manager@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.2.1.tgz#8b38237c154a377f6e199b77ecc871c6c6bb41a4"
+  integrity sha512-wiS/kE0Ny5pnjTxVCs8ljRnkL1RVMj59t6jmSsgEX7piDOoaXSMIUaoIt9ogS/v132uO0xEsxHstkRUZHQyPcQ==
   dependencies:
-    "@docusaurus/core" "3.1.0"
-    "@docusaurus/types" "3.1.0"
-    "@docusaurus/utils-validation" "3.1.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-ideal-image@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-ideal-image/-/plugin-ideal-image-3.1.0.tgz#a1667beca8efb03a0730083a479fe99b064ba7ef"
-  integrity sha512-ytT7f3hCM78yyv8Km3DIE1Myqp5GEGE8JnRz98wUWDzZq1tNroe+dhrLTqI2D4iqwOYFMcjFQkcvK0vDkLG7cw==
+"@docusaurus/plugin-ideal-image@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-ideal-image/-/plugin-ideal-image-3.2.1.tgz#c7fc8d24d424afe22753a7188ea4525cf7248065"
+  integrity sha512-Mf/C6jsCuiyC2xME/qBJ73ZwrXN10WaPTBWXI3ZR5d+nqZX+b4bKJJB/0RMt+lgQHELT/nB8Yk+wc10bMX4xJw==
   dependencies:
-    "@docusaurus/core" "3.1.0"
-    "@docusaurus/lqip-loader" "3.1.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/lqip-loader" "3.2.1"
     "@docusaurus/responsive-loader" "^1.7.0"
-    "@docusaurus/theme-translations" "3.1.0"
-    "@docusaurus/types" "3.1.0"
-    "@docusaurus/utils-validation" "3.1.0"
+    "@docusaurus/theme-translations" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     "@slorber/react-ideal-image" "^0.0.12"
     react-waypoint "^10.3.0"
     sharp "^0.32.3"
     tslib "^2.6.0"
     webpack "^5.88.1"
 
-"@docusaurus/plugin-sitemap@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.1.0.tgz#9d9dbb4d87e6dc46ae9321badf6ac7cd9aa96b23"
-  integrity sha512-TkR5vGBpUooEB9SoW42thahqqwKzfHrQQhkB+JrEGERsl4bKODSuJNle4aA4h6LSkg4IyfXOW8XOI0NIPWb9Cg==
+"@docusaurus/plugin-sitemap@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.2.1.tgz#306b3e34cfbe38582ccbbd85d83ce0bdd0ae4cf7"
+  integrity sha512-uWZ7AxzdeaQSTCwD2yZtOiEm9zyKU+wqCmi/Sf25kQQqqFSBZUStXfaQ8OHP9cecnw893ZpZ811rPhB/wfujJw==
   dependencies:
-    "@docusaurus/core" "3.1.0"
-    "@docusaurus/logger" "3.1.0"
-    "@docusaurus/types" "3.1.0"
-    "@docusaurus/utils" "3.1.0"
-    "@docusaurus/utils-common" "3.1.0"
-    "@docusaurus/utils-validation" "3.1.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/logger" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-common" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     fs-extra "^11.1.1"
     sitemap "^7.1.1"
     tslib "^2.6.0"
 
-"@docusaurus/preset-classic@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-3.1.0.tgz#ca67d5e416c211b4c23f0fb01f0e3e36b759dfa0"
-  integrity sha512-xGLQRFmmT9IinAGUDVRYZ54Ys28USNbA3OTXQXnSJLPr1rCY7CYnHI4XoOnKWrNnDiAI4ruMzunXWyaElUYCKQ==
+"@docusaurus/preset-classic@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-3.2.1.tgz#25a18ebaf271ec91ab7430a76a9054f101593de1"
+  integrity sha512-E3OHSmttpEBcSMhfPBq3EJMBxZBM01W1rnaCUTXy9EHvkmB5AwgTfW1PwGAybPAX579ntE03R+2zmXdizWfKnQ==
   dependencies:
-    "@docusaurus/core" "3.1.0"
-    "@docusaurus/plugin-content-blog" "3.1.0"
-    "@docusaurus/plugin-content-docs" "3.1.0"
-    "@docusaurus/plugin-content-pages" "3.1.0"
-    "@docusaurus/plugin-debug" "3.1.0"
-    "@docusaurus/plugin-google-analytics" "3.1.0"
-    "@docusaurus/plugin-google-gtag" "3.1.0"
-    "@docusaurus/plugin-google-tag-manager" "3.1.0"
-    "@docusaurus/plugin-sitemap" "3.1.0"
-    "@docusaurus/theme-classic" "3.1.0"
-    "@docusaurus/theme-common" "3.1.0"
-    "@docusaurus/theme-search-algolia" "3.1.0"
-    "@docusaurus/types" "3.1.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/plugin-content-blog" "3.2.1"
+    "@docusaurus/plugin-content-docs" "3.2.1"
+    "@docusaurus/plugin-content-pages" "3.2.1"
+    "@docusaurus/plugin-debug" "3.2.1"
+    "@docusaurus/plugin-google-analytics" "3.2.1"
+    "@docusaurus/plugin-google-gtag" "3.2.1"
+    "@docusaurus/plugin-google-tag-manager" "3.2.1"
+    "@docusaurus/plugin-sitemap" "3.2.1"
+    "@docusaurus/theme-classic" "3.2.1"
+    "@docusaurus/theme-common" "3.2.1"
+    "@docusaurus/theme-search-algolia" "3.2.1"
+    "@docusaurus/types" "3.2.1"
 
 "@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
@@ -1544,13 +1530,13 @@
     "@types/react" "*"
     prop-types "^15.6.2"
 
-"@docusaurus/remark-plugin-npm2yarn@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/remark-plugin-npm2yarn/-/remark-plugin-npm2yarn-3.1.0.tgz#357853e42cc23b00b2fce3ed470001dc84f8cc3d"
-  integrity sha512-+dUortlwU8kEmEyrI/b5e1eu6BPIjaS4T/iU54pxVGo4thwj4luB8eqXDLgz2OjBqfUsEFf/Of3dgRueph7mXQ==
+"@docusaurus/remark-plugin-npm2yarn@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/remark-plugin-npm2yarn/-/remark-plugin-npm2yarn-3.2.1.tgz#c218056d91e7e84fc41cef8cd19fa5c40ec09861"
+  integrity sha512-10sLhtIp2O0T7uEqVz82T4luXjnKiishwRbCAO+HgdFTsoVWs3RmrZHdk4Y5/s4Kgl2ptUPZIec3RdPoTY9vcA==
   dependencies:
     mdast-util-mdx "^3.0.0"
-    npm-to-yarn "^2.0.0"
+    npm-to-yarn "^2.2.1"
     tslib "^2.6.0"
     unified "^11.0.3"
     unist-util-visit "^5.0.0"
@@ -1562,23 +1548,23 @@
   dependencies:
     loader-utils "^2.0.0"
 
-"@docusaurus/theme-classic@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-3.1.0.tgz#6ee68bf4d4db53c8d9b18d4866512abadb00a802"
-  integrity sha512-/+jMl2Z9O8QQxves5AtHdt91gWsEZFgOV3La/6eyKEd7QLqQUtM5fxEJ40rq9NKYjqCd1HzZ9egIMeJoWwillw==
+"@docusaurus/theme-classic@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-3.2.1.tgz#0aea144bbbfa77b699f6eff7ffaeb36a1adc6c02"
+  integrity sha512-+vSbnQyoWjc6vRZi4vJO2dBU02wqzynsai15KK+FANZudrYaBHtkbLZAQhgmxzBGVpxzi87gRohlMm+5D8f4tA==
   dependencies:
-    "@docusaurus/core" "3.1.0"
-    "@docusaurus/mdx-loader" "3.1.0"
-    "@docusaurus/module-type-aliases" "3.1.0"
-    "@docusaurus/plugin-content-blog" "3.1.0"
-    "@docusaurus/plugin-content-docs" "3.1.0"
-    "@docusaurus/plugin-content-pages" "3.1.0"
-    "@docusaurus/theme-common" "3.1.0"
-    "@docusaurus/theme-translations" "3.1.0"
-    "@docusaurus/types" "3.1.0"
-    "@docusaurus/utils" "3.1.0"
-    "@docusaurus/utils-common" "3.1.0"
-    "@docusaurus/utils-validation" "3.1.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/mdx-loader" "3.2.1"
+    "@docusaurus/module-type-aliases" "3.2.1"
+    "@docusaurus/plugin-content-blog" "3.2.1"
+    "@docusaurus/plugin-content-docs" "3.2.1"
+    "@docusaurus/plugin-content-pages" "3.2.1"
+    "@docusaurus/theme-common" "3.2.1"
+    "@docusaurus/theme-translations" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-common" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     "@mdx-js/react" "^3.0.0"
     clsx "^2.0.0"
     copy-text-to-clipboard "^3.2.0"
@@ -1593,18 +1579,18 @@
     tslib "^2.6.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-common@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-3.1.0.tgz#d176af1d0fc8ea27fea0afb298157f9a75256336"
-  integrity sha512-YGwEFALLIbF5ocW/Fy6Ae7tFWUOugEN3iwxTx8UkLAcLqYUboDSadesYtVBmRCEB4FVA2qoP7YaW3lu3apUPPw==
+"@docusaurus/theme-common@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-3.2.1.tgz#017b0cf05de2a4fa7b117ee44f25a3e8541c8bb9"
+  integrity sha512-d+adiD7L9xv6EvfaAwUqdKf4orsM3jqgeqAM+HAjgL/Ux0GkVVnfKr+tsoe+4ow4rHe6NUt+nkkW8/K8dKdilA==
   dependencies:
-    "@docusaurus/mdx-loader" "3.1.0"
-    "@docusaurus/module-type-aliases" "3.1.0"
-    "@docusaurus/plugin-content-blog" "3.1.0"
-    "@docusaurus/plugin-content-docs" "3.1.0"
-    "@docusaurus/plugin-content-pages" "3.1.0"
-    "@docusaurus/utils" "3.1.0"
-    "@docusaurus/utils-common" "3.1.0"
+    "@docusaurus/mdx-loader" "3.2.1"
+    "@docusaurus/module-type-aliases" "3.2.1"
+    "@docusaurus/plugin-content-blog" "3.2.1"
+    "@docusaurus/plugin-content-docs" "3.2.1"
+    "@docusaurus/plugin-content-pages" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-common" "3.2.1"
     "@types/history" "^4.7.11"
     "@types/react" "*"
     "@types/react-router-config" "*"
@@ -1614,47 +1600,47 @@
     tslib "^2.6.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-live-codeblock@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-live-codeblock/-/theme-live-codeblock-3.1.0.tgz#f25ae96f06b4a669a54b59a842c59148ccd137f8"
-  integrity sha512-wJMa5iIA9LwJxBoPu/bCOiffdOggeU2VfGmu9l83gzLQ2l3CL2zUrdOcZzeU3FqFCns5mUSZfDZXmZp2tbWPiw==
+"@docusaurus/theme-live-codeblock@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-live-codeblock/-/theme-live-codeblock-3.2.1.tgz#546a7f1b6ccc6b6bb2965e3d91aa6c2c4dd6b674"
+  integrity sha512-K1J6bC5rDbF+jfZrjm7byxLUk1R/flgnozU5LflE5FL3+Y/rW72TXshWAghSKWOP6crhLJP1BsoJ9mRf/9KB3Q==
   dependencies:
-    "@docusaurus/core" "3.1.0"
-    "@docusaurus/theme-common" "3.1.0"
-    "@docusaurus/theme-translations" "3.1.0"
-    "@docusaurus/utils-validation" "3.1.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/theme-common" "3.2.1"
+    "@docusaurus/theme-translations" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     "@philpl/buble" "^0.19.7"
     clsx "^2.0.0"
     fs-extra "^11.1.1"
     react-live "^4.1.5"
     tslib "^2.6.0"
 
-"@docusaurus/theme-mermaid@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-mermaid/-/theme-mermaid-3.1.0.tgz#1e7f8e96e21b5d180043f8f7793f1b38045c5806"
-  integrity sha512-63y08fvRWIe9satRV1e/Dps9he+sPjQ+kwl4ccQQEzkM2nxeAgWwk8WzpbVhm1Pf02N/11y0C6FcvFqn4dERHA==
+"@docusaurus/theme-mermaid@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-mermaid/-/theme-mermaid-3.2.1.tgz#ee17d8d2115f0c4a046427ade3c7a77fe4dfbf6f"
+  integrity sha512-l1FzUPgDUor/25XeJDeO22dttmzB0QnmAbF2qKjDz3ENa9vlD5rd5r0NrItZIe8y7qoa+OOxkl5lLBKBxBVbLg==
   dependencies:
-    "@docusaurus/core" "3.1.0"
-    "@docusaurus/module-type-aliases" "3.1.0"
-    "@docusaurus/theme-common" "3.1.0"
-    "@docusaurus/types" "3.1.0"
-    "@docusaurus/utils-validation" "3.1.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/module-type-aliases" "3.2.1"
+    "@docusaurus/theme-common" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     mermaid "^10.4.0"
     tslib "^2.6.0"
 
-"@docusaurus/theme-search-algolia@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.1.0.tgz#3cdb1f0e8d15698a60110856ca5a06f10d3b049d"
-  integrity sha512-8cJH0ZhPsEDjq3jR3I+wHmWzVY2bXMQJ59v2QxUmsTZxbWA4u+IzccJMIJx4ooFl9J6iYynwYsFuHxyx/KUmfQ==
+"@docusaurus/theme-search-algolia@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.2.1.tgz#6617d43ab0726b744bf8e32eb8533417c0d66b7d"
+  integrity sha512-bzhCrpyXBXzeydNUH83II2akvFEGfhsNTPPWsk5N7e+odgQCQwoHhcF+2qILbQXjaoZ6B3c48hrvkyCpeyqGHw==
   dependencies:
     "@docsearch/react" "^3.5.2"
-    "@docusaurus/core" "3.1.0"
-    "@docusaurus/logger" "3.1.0"
-    "@docusaurus/plugin-content-docs" "3.1.0"
-    "@docusaurus/theme-common" "3.1.0"
-    "@docusaurus/theme-translations" "3.1.0"
-    "@docusaurus/utils" "3.1.0"
-    "@docusaurus/utils-validation" "3.1.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/logger" "3.2.1"
+    "@docusaurus/plugin-content-docs" "3.2.1"
+    "@docusaurus/theme-common" "3.2.1"
+    "@docusaurus/theme-translations" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     algoliasearch "^4.18.0"
     algoliasearch-helper "^3.13.3"
     clsx "^2.0.0"
@@ -1664,37 +1650,23 @@
     tslib "^2.6.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-translations@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-translations/-/theme-translations-3.1.0.tgz#1c6bdc19723a87e042b5e89b6cdc8b747fdcbc13"
-  integrity sha512-DApE4AbDI+WBajihxB54L4scWQhVGNZAochlC9fkbciPuFAgdRBD3NREb0rgfbKexDC/rioppu/WJA0u8tS+yA==
+"@docusaurus/theme-translations@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-translations/-/theme-translations-3.2.1.tgz#894f6cb5bb121aa45a4a5f1383b70a8e3ae6a5d9"
+  integrity sha512-jAUMkIkFfY+OAhJhv6mV8zlwY6J4AQxJPTgLdR2l+Otof9+QdJjHNh/ifVEu9q0lp3oSPlJj9l05AaP7Ref+cg==
   dependencies:
     fs-extra "^11.1.1"
     tslib "^2.6.0"
 
-"@docusaurus/tsconfig@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/tsconfig/-/tsconfig-3.0.1.tgz#170f230c34ff12e55995bd7e9f1f21db33035d8f"
-  integrity sha512-hT2HCdNE3pWTzXV/7cSsowfmaOxXVOTFOXmkqaYjBWjaxjJ3FO0nHbdJ8rF6Da7PvWmIPbUekdP5gep1XCJ7Vg==
+"@docusaurus/tsconfig@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/tsconfig/-/tsconfig-3.2.1.tgz#6bdc0cb46414d09c7334d632b6d5e5472e6eb5a7"
+  integrity sha512-+biUwtsYW3oChLxYezzA+NIgS3Q9KDRl7add/YT54RXs9Q4rKInebxdHdG6JFs5BaTg45gyjDu0rvNVcGeHODg==
 
-"@docusaurus/types@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-3.0.1.tgz#4fe306aa10ef7c97dbc07588864f6676a40f3b6f"
-  integrity sha512-plyX2iU1tcUsF46uQ01pAd4JhexR7n0iiQ5MSnBFX6M6NSJgDYdru/i1/YNPKOnQHBoXGLHv0dNT6OAlDWNjrg==
-  dependencies:
-    "@types/history" "^4.7.11"
-    "@types/react" "*"
-    commander "^5.1.0"
-    joi "^17.9.2"
-    react-helmet-async "^1.3.0"
-    utility-types "^3.10.0"
-    webpack "^5.88.1"
-    webpack-merge "^5.9.0"
-
-"@docusaurus/types@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-3.1.0.tgz#1dbb60ea38e98ba869f8d7ea2323e4460f05ab65"
-  integrity sha512-VaczOZf7+re8aFBIWnex1XENomwHdsSTkrdX43zyor7G/FY4OIsP6X28Xc3o0jiY0YdNuvIDyA5TNwOtpgkCVw==
+"@docusaurus/types@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-3.2.1.tgz#88ccd4b8fa236628a29c89b8b0f60f0cc4716b69"
+  integrity sha512-n/toxBzL2oxTtRTOFiGKsHypzn/Pm+sXyw+VSk1UbqbXQiHOwHwts55bpKwbcUgA530Is6kix3ELiFOv9GAMfw==
   dependencies:
     "@mdx-js/mdx" "^3.0.0"
     "@types/history" "^4.7.11"
@@ -1706,30 +1678,32 @@
     webpack "^5.88.1"
     webpack-merge "^5.9.0"
 
-"@docusaurus/utils-common@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils-common/-/utils-common-3.1.0.tgz#846ce9c12b9ebf1ebf513e65303fb8158dcd2e1b"
-  integrity sha512-SfvnRLHoZ9bwTw67knkSs7IcUR0GY2SaGkpdB/J9pChrDiGhwzKNUhcieoPyPYrOWGRPk3rVNYtoy+Bc7psPAw==
+"@docusaurus/utils-common@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-common/-/utils-common-3.2.1.tgz#c275fd9984951244cc4f595ce6dfd0522e40c68d"
+  integrity sha512-N5vadULnRLiqX2QfTjVEU3u5vo6RG2EZTdyXvJdzDOdrLCGIZAfnf/VkssinFZ922sVfaFfQ4FnStdhn5TWdVg==
   dependencies:
     tslib "^2.6.0"
 
-"@docusaurus/utils-validation@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-3.1.0.tgz#3e88c42caec29cd3eedbbd17af97f88719613340"
-  integrity sha512-dFxhs1NLxPOSzmcTk/eeKxLY5R+U4cua22g9MsAMiRWcwFKStZ2W3/GDY0GmnJGqNS8QAQepJrxQoyxXkJNDeg==
+"@docusaurus/utils-validation@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-3.2.1.tgz#42ff0d2ae11c81d199ea485f27b86b40779673ed"
+  integrity sha512-+x7IR9hNMXi62L1YAglwd0s95fR7+EtirjTxSN4kahYRWGqOi3jlQl1EV0az/yTEvKbxVvOPcdYicGu9dk4LJw==
   dependencies:
-    "@docusaurus/logger" "3.1.0"
-    "@docusaurus/utils" "3.1.0"
+    "@docusaurus/logger" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-common" "3.2.1"
     joi "^17.9.2"
     js-yaml "^4.1.0"
     tslib "^2.6.0"
 
-"@docusaurus/utils@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-3.1.0.tgz#6ef821bc4c40a91586835a385110b5c0082c590c"
-  integrity sha512-LgZfp0D+UBqAh7PZ//MUNSFBMavmAPku6Si9x8x3V+S318IGCNJ6hUr2O29UO0oLybEWUjD5Jnj9IUN6XyZeeg==
+"@docusaurus/utils@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-3.2.1.tgz#25247d071618bc7ece9bbc3d59f3ee1ac3ded727"
+  integrity sha512-DPkIS/EPc+pGAV798PUXgNzJFM3HJouoQXgr0KDZuJVz1EkWbDLOcQwLIz8Qx7liI9ddfkN/TXTRQdsTPZNakw==
   dependencies:
-    "@docusaurus/logger" "3.1.0"
+    "@docusaurus/logger" "3.2.1"
+    "@docusaurus/utils-common" "3.2.1"
     "@svgr/webpack" "^6.5.1"
     escape-string-regexp "^4.0.0"
     file-loader "^6.2.0"
@@ -1741,6 +1715,7 @@
     js-yaml "^4.1.0"
     lodash "^4.17.21"
     micromatch "^4.0.5"
+    prompts "^2.4.2"
     resolve-pathname "^3.0.0"
     shelljs "^0.8.5"
     tslib "^2.6.0"
@@ -1971,15 +1946,6 @@
     micromark-factory-space "^1.0.0"
     micromark-util-character "^1.1.0"
     micromark-util-symbol "^1.0.1"
-
-"@slorber/static-site-generator-webpack-plugin@^4.0.7":
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/@slorber/static-site-generator-webpack-plugin/-/static-site-generator-webpack-plugin-4.0.7.tgz#fc1678bddefab014e2145cbe25b3ce4e1cfc36f3"
-  integrity sha512-Ug7x6z5lwrz0WqdnNFOMYrDQNTPAprvHLSh6+/fmml3qUiz6l5eq+2MzLKWtn/q5K5NpSiFsZTP/fck/3vjSxA==
-  dependencies:
-    eval "^0.1.8"
-    p-map "^4.0.0"
-    webpack-sources "^3.2.2"
 
 "@stoplight/json-ref-resolver@^3.1.5":
   version "3.1.6"
@@ -7895,10 +7861,10 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-npm-to-yarn@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/npm-to-yarn/-/npm-to-yarn-2.1.0.tgz#ff4e18028d18eb844691f1ccb556be5f3ccfde34"
-  integrity sha512-2C1IgJLdJngq1bSER7K7CGFszRr9s2rijEwvENPEgI0eK9xlD3tNwDc0UJnRj7FIT2aydWm72jB88uVswAhXHA==
+npm-to-yarn@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/npm-to-yarn/-/npm-to-yarn-2.2.1.tgz#048843a6630621daffc6a239dfc89698b8abf7e8"
+  integrity sha512-O/j/ROyX0KGLG7O6Ieut/seQ0oiTpHF2tXAcFbpdTLQFiaNtkyTXXocM1fwpaa60dg1qpWj0nHlbNhx6qwuENQ==
 
 nprogress@^0.2.0:
   version "0.2.0"
@@ -10816,7 +10782,7 @@ webpack-merge@^5.9.0:
     flat "^5.0.2"
     wildcard "^2.0.0"
 
-webpack-sources@^3.2.2, webpack-sources@^3.2.3:
+webpack-sources@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==


### PR DESCRIPTION
# Description

This PR bumps the dependencies for docusaurus to v3.2.1.

# Changes

- [x] Docusaurus bump to 3.2.1
- [x] Enforce anchor checking