### PR TITLE
Add warnings for upcoming CoW AMM standalone implementation

### DIFF
--- a/docs/cow-protocol/reference/contracts/programmatic/cow-amm.md
+++ b/docs/cow-protocol/reference/contracts/programmatic/cow-amm.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # CoW AMM
 
-:::warning
+:::caution
 
 This documentation refers to the CoW AMM implementation based on the programmable order framework, which relies on Safe Multisigs to create and validate AMM orders.
 We are working on releasing a simpler and more efficient standalone version in the coming weeks.

--- a/docs/cow-protocol/reference/contracts/programmatic/cow-amm.md
+++ b/docs/cow-protocol/reference/contracts/programmatic/cow-amm.md
@@ -4,6 +4,16 @@ sidebar_position: 1
 
 # CoW AMM
 
+:::warning
+
+This documentation refers to the CoW AMM implementation based on the programmable order framework, which relies on Safe Multisigs to create and validate AMM orders.
+We are working on releasing a simpler and more efficient standalone version in the coming weeks.
+
+The [code for the version covered by this documentation](https://github.com/cowprotocol/cow-amm/tree/amm-based-on-safe-multisig) is tagged `amm-based-on-safe-multisig`.
+
+:::
+
+
 CoW AMM is an automated market maker running on top of CoW Protocol.
 
 ## Overview

--- a/docs/cow-protocol/tutorials/solvers/cow-amm.md
+++ b/docs/cow-protocol/tutorials/solvers/cow-amm.md
@@ -4,6 +4,17 @@ sidebar_position: 6
 
 # CoW AMM Liquidity
 
+:::warning
+
+This documentation refers to the CoW AMM implementation based on the programmable order framework, which relies on Safe Multisigs to create and validate AMM orders.
+We are working on releasing a simpler and more efficient standalone version in the coming weeks.
+Most of this guide will still be applicable, but order signature generation will change and there will be no need to reset the commitment anymore.
+The newer version will also make it easier to retrieve and index information for all CoW AMMs.
+
+The [code for the version covered by this documentation](https://github.com/cowprotocol/cow-amm/tree/amm-based-on-safe-multisig) is tagged `amm-based-on-safe-multisig`.
+
+:::
+
 ## I'm a solver. How do I use CoW AMM liquidity?
 
 CoW AMM orders already appear in the CoW Protocol orderbook, so you're already using its liquidity.

--- a/docs/cow-protocol/tutorials/solvers/cow-amm.md
+++ b/docs/cow-protocol/tutorials/solvers/cow-amm.md
@@ -4,7 +4,7 @@ sidebar_position: 6
 
 # CoW AMM Liquidity
 
-:::warning
+:::caution
 
 This documentation refers to the CoW AMM implementation based on the programmable order framework, which relies on Safe Multisigs to create and validate AMM orders.
 We are working on releasing a simpler and more efficient standalone version in the coming weeks.


### PR DESCRIPTION
# Description

Add warning that changes to the CoW AMMs are upcoming.

# Changes

- New warning on CoW AMM pages. Notably, the page `CoW AMM Liquidity`, which we give to solvers as a reference for working with CoW AMMs.