### PR TITLE
docs(widget): flexible config for partner fee params (#392)

### DIFF
--- a/docs/cow-protocol/tutorials/widget/widget.md
+++ b/docs/cow-protocol/tutorials/widget/widget.md
@@ -69,6 +69,8 @@ const params: CowSwapWidgetParams = {
 createCowSwapWidget(widgetContainer, { params })
 ```
 
+This configuration will apply a partner fee for all networks, and trade types (swaps, limit orders, TWAPs, etc.). You can use [Flexible config](#flexible-config) for having more flexibility, or [Advanced configuration](#advanced-configuration) to have even more on you partner fee.
+
 ### Flexible config
 
 Both `bps` and `recipient` can be set for different chains and different trade types (swap/limit/advanced). 

--- a/docs/cow-protocol/tutorials/widget/widget.md
+++ b/docs/cow-protocol/tutorials/widget/widget.md
@@ -69,7 +69,7 @@ const params: CowSwapWidgetParams = {
 createCowSwapWidget(widgetContainer, { params })
 ```
 
-This configuration will apply a partner fee for all networks, and trade types (swaps, limit orders, TWAPs, etc.). You can use [Flexible config](#flexible-config) for having more flexibility, or [Advanced configuration](#advanced-configuration) to have even more on you partner fee.
+This configuration will apply a partner fee for all networks and trade types (swaps, limit orders, TWAPs, etc.). You can use [Flexible config](#flexible-config) for having more flexibility, or [Advanced configuration](#advanced-configuration) to have even more control on you partner fee.
 
 ### Flexible config
 

--- a/docs/cow-protocol/tutorials/widget/widget.md
+++ b/docs/cow-protocol/tutorials/widget/widget.md
@@ -69,7 +69,7 @@ const params: CowSwapWidgetParams = {
 createCowSwapWidget(widgetContainer, { params })
 ```
 
-This configuration will apply a partner fee for all networks and trade types (swaps, limit orders, TWAPs, etc.). You can use [Flexible config](#flexible-config) for having more flexibility, or [Advanced configuration](#advanced-configuration) to have even more control on you partner fee.
+This configuration will apply a partner fee for all networks and trade types (swaps, limit orders, TWAPs, etc.). You can use [Flexible config](#flexible-config) for having more flexibility, or [Advanced configuration](#advanced-configuration) to have even more control over the partner fee configuration parameters.
 
 ### Flexible config
 


### PR DESCRIPTION
# Description

Adds some additional information on the options for partner fee, so we are more explicit saying that the simplest config will affect all flows and networks.

<img width="1038" alt="image" src="https://github.com/cowprotocol/docs/assets/2352112/09e2efc5-4570-4d26-93f2-4f6a9b83b6f8">



## Test
Review https://docs-git-clarify-partner-fee-options-cowswap.vercel.app/cow-protocol/tutorials/widget#partner-fee
