### PR TITLE
Update docs: /reveal endpoint removed

### DIFF
--- a/docs/cow-protocol/tutorials/arbitrate/README.mdx
+++ b/docs/cow-protocol/tutorials/arbitrate/README.mdx
@@ -24,7 +24,6 @@ sequenceDiagram
     activate Solver
     Solver-->>Autopilot: Score
     deactivate Solver
-    Autopilot->>Solver: /reveal
     activate Solver
     Solver-->>Autopilot: Solution with call data
     deactivate Solver

--- a/docs/cow-protocol/tutorials/arbitrate/README.mdx
+++ b/docs/cow-protocol/tutorials/arbitrate/README.mdx
@@ -25,7 +25,6 @@ sequenceDiagram
     Solver-->>Autopilot: Score
     deactivate Solver
     activate Solver
-    Solver-->>Autopilot: Solution with call data
     deactivate Solver
     Autopilot->>Solver: /settle
     activate Solver

--- a/docs/cow-protocol/tutorials/arbitrate/README.mdx
+++ b/docs/cow-protocol/tutorials/arbitrate/README.mdx
@@ -24,8 +24,6 @@ sequenceDiagram
     activate Solver
     Solver-->>Autopilot: Score
     deactivate Solver
-    activate Solver
-    deactivate Solver
     Autopilot->>Solver: /settle
     activate Solver
     Note over Solver: Settles transaction on-chain

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -61,10 +61,8 @@ sequenceDiagram
     solver 1->>autopilot: Proposed batch
     deactivate solver 1
     solver 2->>autopilot: Proposed batch
-    deactivate solver 2
 
     Note over autopilot: Pick winner
-    solver 2->>-autopilot: Ethereum transaction data
     autopilot->>+solver 2: /settle
     solver 2->>+blockchain: Execute transaction
     blockchain->>-solver 2: Transaction receipt

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -119,7 +119,7 @@ The scoring process is described in detail in the [description of CoW Protocol's
 The autopilot selects the winner according to the highest score once the allotted time expires or all solvers have returned their batch proposal.
 
 Up to this point, the autopilot only knows the score.
-The autopilot then execute the corresponding settlement transaction (`/settle`).
+The autopilot then tells the winning driver to execute the settlement (`/settle`).
 The solver is responsible for executing the transaction on-chain (through the [driver](./solver/driver) if using the reference implementation).
 
 ### Auction data storage

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -64,7 +64,6 @@ sequenceDiagram
     deactivate solver 2
 
     Note over autopilot: Pick winner
-    autopilot->>+solver 2: /reveal
     solver 2->>-autopilot: Ethereum transaction data
     autopilot->>+solver 2: /settle
     solver 2->>+blockchain: Execute transaction
@@ -122,7 +121,6 @@ The scoring process is described in detail in the [description of CoW Protocol's
 The autopilot selects the winner according to the highest score once the allotted time expires or all solvers have returned their batch proposal.
 
 Up to this point, the autopilot only knows the score and not the full solution that achieves that score.
-The autopilot then asks the winning solver to reveal its score (through `/reveal`) and then to execute the corresponding settlement transaction (`/settle`).
 The solver is responsible for executing the transaction on-chain (through the [driver](./solver/driver) if using the reference implementation).
 
 ### Auction data storage

--- a/docs/cow-protocol/tutorials/arbitrate/autopilot.md
+++ b/docs/cow-protocol/tutorials/arbitrate/autopilot.md
@@ -118,7 +118,8 @@ Solvers have a short amount of time (seconds) to come up with a [solution](/cow-
 The scoring process is described in detail in the [description of CoW Protocol's optimization problem](/cow-protocol/reference/core/auctions/the-problem).
 The autopilot selects the winner according to the highest score once the allotted time expires or all solvers have returned their batch proposal.
 
-Up to this point, the autopilot only knows the score and not the full solution that achieves that score.
+Up to this point, the autopilot only knows the score.
+The autopilot then execute the corresponding settlement transaction (`/settle`).
 The solver is responsible for executing the transaction on-chain (through the [driver](./solver/driver) if using the reference implementation).
 
 ### Auction data storage

--- a/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
+++ b/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
@@ -37,7 +37,6 @@ sequenceDiagram
     solver engine-->>driver: set of solutions
     driver->>driver: post-process solutions
     driver-->>autopilot: participate with the best solution
-    autopilot->>driver: request to reveal details about the settlement,<br>in case this solver won
     autopilot->>driver: request to execute the settlement,<br>in case this solver won
     driver->>driver: execute the settlement
 ```

--- a/docs/cow-protocol/tutorials/solvers/test.md
+++ b/docs/cow-protocol/tutorials/solvers/test.md
@@ -145,7 +145,7 @@ Starting from this hash, we can use the competition endpoint:
 
 [https://api.cow.fi/mainnet/api/v1/solver_competition/by_tx_hash/0x17271e39305217d36635afbcc882e9431f9195d561d814aba96986cdd12dd240](https://api.cow.fi/mainnet/api/v1/solver_competition/by_tx_hash/0x17271e39305217d36635afbcc882e9431f9195d561d814aba96986cdd12dd240)
 
-and then we can see that the auction id was 6462225. Note also that the competition endpoint reveals the calldata of all submitted solutions that successfully simulated and got ranked.
+and then we can see that the auction id was 6462225.
 
 Using this id, we can now recover the instance.json of that auction:
 


### PR DESCRIPTION
# Description
Remove the references to `/reveal` endpoint, since it was removed.

Fixes #2942