### PR TITLE
Update rewards.md

### DIFF
--- a/docs/cow-protocol/reference/core/auctions/rewards.md
+++ b/docs/cow-protocol/reference/core/auctions/rewards.md
@@ -4,9 +4,8 @@ sidebar_position: 3
 
 # Solver rewards
 
-The protocol is currently subsidizing the solver competition on Ethereum Mainnet (but not on Gnosis Chain nor Arbitrum One), by rewarding solvers on a weekly basis (currently, every Tuesday) with rewards paid in COW. Solvers are rewarded based on their performance as solvers (i.e. when participating in the standard solver competition) as specified by [CIP-20](https://snapshot.org/#/cow.eth/proposal/0x2d3f9bd1ea72dca84b03e97dda3efc1f4a42a772c54bd2037e8b62e7d09a491f), [CIP-36](https://snapshot.org/#/cow.eth/proposal/0x4e58f9c1208121c0e06282b5541b458bc8c8b76090263e25448848f3194df986), and [CIP-38](https://snapshot.org/#/cow.eth/proposal/0xfb81daea9be89f4f1c251d53fd9d1481129b97c6f38caaddc42af7f3ce5a52ec). Solver rewards for participating in the price estimation competition and providing quotes that are needed for the gas estimates and limit price computations of market orders are specified in [CIP-27](https://snapshot.org/#/cow.eth/proposal/0x64e061568e86e8d2eec344d4a892e4126172b992cabe59a0b24c51c4c7e6cc33) and [CIP-36](https://snapshot.org/#/cow.eth/proposal/0x4e58f9c1208121c0e06282b5541b458bc8c8b76090263e25448848f3194df986).
+The protocol is currently subsidizing the solver competition on Ethereum Mainnet (but not on Gnosis Chain nor Arbitrum One), by rewarding solvers on a weekly basis (currently, every Tuesday) with rewards paid in COW. Solvers are rewarded based on their performance as solvers (i.e., when participating in the standard solver competition) as specified by [CIP-20](https://snapshot.org/#/cow.eth/proposal/0x2d3f9bd1ea72dca84b03e97dda3efc1f4a42a772c54bd2037e8b62e7d09a491f), [CIP-36](https://snapshot.org/#/cow.eth/proposal/0x4e58f9c1208121c0e06282b5541b458bc8c8b76090263e25448848f3194df986), [CIP-38](https://snapshot.org/#/cow.eth/proposal/0xfb81daea9be89f4f1c251d53fd9d1481129b97c6f38caaddc42af7f3ce5a52ec), and [CIP-48](https://snapshot.org/#/cow.eth/proposal/0x563ab9a66265ad72c47a8e55f620f927685dd07d4d49f6d1812905c683f05805). Solver rewards for participating in the price estimation competition and providing quotes that are needed for the gas estimates and limit price computations of market orders are specified in [CIP-27](https://snapshot.org/#/cow.eth/proposal/0x64e061568e86e8d2eec344d4a892e4126172b992cabe59a0b24c51c4c7e6cc33) and [CIP-36](https://snapshot.org/#/cow.eth/proposal/0x4e58f9c1208121c0e06282b5541b458bc8c8b76090263e25448848f3194df986).
 
-The annual rewards budget as of now is 16M COW, and the intended split between solver competition and price estimation rewards is currently 80% for the solver competition (12.8M COW) and 20% for the price estimation competition (3.2M COW).
 
 :::note
 
@@ -14,13 +13,9 @@ For the interested reader, the main source of truth for the weekly payments to s
 
 :::
 
-## Solver competition rewards (CIP-20 & CIP-36 & CIP-38)
+## Solver competition rewards (CIP-20 & CIP-36 & CIP-38 & CIP-48)
 
-Solver competition rewards are split into two components: per-auction rewards and consistency rewards. 
-
-### Per-auction rewards
-
-The per-auction rewards are computed using a mechanism akin to a second-price auction. First, each solver commits a solution, which includes a price vector and a list of trades to execute. The solver proposing the solution with the highest quality wins the right to settle their submitted solution on chain, where quality is the sum of surplus delivered to users and fees paid to the protocol.
+Solvers' rewards are computed using a mechanism akin to a second-price auction. First, each solver commits a solution, which includes a price vector and a list of trades to execute. The solver proposing the solution with the highest quality wins the right to settle their submitted solution on chain, where quality is the sum of surplus delivered to users and fees paid to the protocol.
 
 :::note
 
@@ -53,9 +48,6 @@ There is no guarantee that the per-auction rewards are greater than the gas cost
 :::
 
 
-### Specification of consistency rewards
-
-Besides the per-auction rewards, solvers are rewarded for their consistency by distributing some additional COW proportionally to the number of auctions for which they provided valid solutions, up to a cap in ETH. As already mentioned, CoW Protocol has committed to spending a specified quantity of COW tokens to reward solvers: an estimated 12.8M COW annual budget is currently allocated for the solver competition rewards in Ethereum, corresponding to an average weekly budget of ~250k COW. Hence, suppose that the total per-auction rewards have been determined and expressed in COW and amount to $$X$$ of COW, as described above. Then, if $$X < 250,000$$, the budget that will be distributed as consistency rewards is $$\min\{250,000 - X \textrm{ COW}, 6 \textrm{ ETH} \}$$, where again, to compare the two quantities, we use an up-to-date price.
 
 ### Additional solver costs (slippage)
 

--- a/docs/cow-protocol/reference/core/auctions/rewards.md
+++ b/docs/cow-protocol/reference/core/auctions/rewards.md
@@ -9,13 +9,13 @@ The protocol is currently subsidizing the solver competition on Ethereum Mainnet
 
 :::note
 
-For the interested reader, the main source of truth for the weekly payments to solvers is this [Dune dashboard](https://dune.com/cowprotocol/cow-solver-rewards?StartTime=2023-11-28+00%3A00%3A00&EndTime=2023-12-05+00%3A00%3A00&EndTime_d3bba3=2023-12-05+00%3A00%3A00&EndTime_dd004a=2023-12-05+00%3A00%3A00&StartTime_d3f009=2023-11-28+00%3A00%3A00). The dashboard is populated with data aggregated by scripts within the [solver-rewards](https://github.com/cowprotocol/solver-rewards) and [dune-sync](https://github.com/cowprotocol/dune-sync/) repositories.
+For the interested reader, the main source of truth for the weekly payments to solvers is this [Dune dashboard](https://dune.com/cowprotocol/cow-solver-rewards). The dashboard is populated with data aggregated by scripts within the [solver-rewards](https://github.com/cowprotocol/solver-rewards) and [dune-sync](https://github.com/cowprotocol/dune-sync/) repositories.
 
 :::
 
 ## Solver competition rewards (CIP-20 & CIP-36 & CIP-38 & CIP-48)
 
-Solvers' rewards are computed using a mechanism akin to a second-price auction. First, each solver commits a solution, which includes a price vector and a list of trades to execute. The solver proposing the solution with the highest quality wins the right to settle their submitted solution on chain, where quality is the sum of surplus delivered to users and fees paid to the protocol.
+Solver rewards are computed using a mechanism akin to a second-price auction. First, each solver commits a solution, which includes a price vector and a list of trades to execute. The solver proposing the solution with the highest quality wins the right to settle their submitted solution on chain, where quality is the sum of surplus delivered to users and fees paid to the protocol.
 
 :::note
 


### PR DESCRIPTION
Include CIP 48: there is no more fixed budget nor consistency rewards

# Description

Updated the docs to reflect CIP-48. In particular, we don't have a fixed budget for rewards. We also don't have consistency rewards anymore


