### PR TITLE
feat: add seo info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-   <img alt="CoW Protocol Logo" width="600" src="./static/img/og-meta-cowprotocol.png">
+   <img alt="Documentation - CoW DAO" width="600" src="./static/img/og-meta-cowprotocol.png">
 </p>
 
 # CoW Protocol Documentation

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -125,12 +125,30 @@ const config: Config = {
   ],
 
   themeConfig: {
+    metadata: [
+      {
+        name: 'description',
+        content: 'Documentation for CoW Protocol, CoW AMM, MEV blocker and other CoW DAO products.',
+      },
+      { name: 'twitter:card', content: 'summary_large_image' },
+      { name: 'og:type', content: 'website' },
+      { name: 'og:image', content: 'img/og-meta-cowprotocol.png' },
+      { name: 'og:title', content: 'Documentation - CoW DAO' },
+      {
+        name: 'og:description',
+        content: 'Documentation for CoW Protocol, CoW AMM, MEV blocker and other CoW DAO products.',
+      },
+      { name: 'twitter:card', content: 'summary_large_image' },
+      { name: 'twitter:site', content: '@CoWSwap' },
+      { name: 'twitter:title', content: 'Documentation - CoW DAO' },
+      { name: 'twitter:image', content: 'img/og-meta-cowprotocol.png' },
+    ],
     // Replace with your project's social card
     image: 'img/og-meta-cowprotocol.png',
     navbar: {
-      title: 'Documentation',
+      title: 'Documentation - CoW DAO',
       logo: {
-        alt: 'CoW Protocol logo',
+        alt: 'Documentation - CoW DAO',
         src: 'img/cow-logo.svg',
         srcDark: 'img/cow-logo-dark.svg',
         href: '/',

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -141,7 +141,7 @@ const config: Config = {
       { name: 'twitter:card', content: 'summary_large_image' },
       { name: 'twitter:site', content: '@CoWSwap' },
       { name: 'twitter:title', content: 'Documentation - CoW DAO' },
-      { name: 'twitter:image', content: 'img/og-meta-cowprotocol.png' },
+      { name: 'twitter:image', content: 'https://docs.cow.fi/img/og-meta-cowprotocol.png' },
     ],
     // Replace with your project's social card
     image: 'img/og-meta-cowprotocol.png',


### PR DESCRIPTION
# Description

I noticed our SEO in the developer docs is not set up. This makes google to create the wrong title for the different links

<img width="1001" alt="image" src="https://github.com/user-attachments/assets/2e5321f2-ea18-40c0-9622-7cc9862f0553">


This PR tries to improve this .

## Test

Check out the HTML. Now it has all the `og:tags` and `<metas />`

<img width="1092" alt="image" src="https://github.com/user-attachments/assets/b0534b4d-3480-476f-802f-2bf0ef430160">


Also, if you past this in twitter/X, you get the right preview

You can use this:
https://www.bannerbear.com/tools/twitter-card-preview-tool/#image_result

<img width="1352" alt="image" src="https://github.com/user-attachments/assets/3673dc92-506a-4af0-a40f-1789c02e45b6">
