### PR TITLE
Typo corrections

### DIFF
--- a/docs/cow-amm/concepts/how-cow-amms-work.md
+++ b/docs/cow-amm/concepts/how-cow-amms-work.md
@@ -16,6 +16,6 @@ CoW AMM pools are optimal for every token pair that is not stable-to-stable. Sin
 
 ## Getting Started with CoW AMM
 
-To faciliate easy liquidity providing, CoW DAO has partnered with Balancer to implement CoW AMMs into the Balancer ecosystem. LPs can [use the Balancer app](https://balancer.fi/pools/cow) to LP direclty on one of over a dozen liquidity pools. 
+To facilitate easy liquidity providing, CoW DAO has partnered with Balancer to implement CoW AMMs into the Balancer ecosystem. LPs can [use the Balancer app](https://balancer.fi/pools/cow) to LP direclty on one of over a dozen liquidity pools. 
 
 In the next section, LPs can learn how to create their own CoW AMM pools for brand new assets either on Balancer or outside the platform. 

--- a/docs/cow-protocol/concepts/benefits/trade-any-intent.md
+++ b/docs/cow-protocol/concepts/benefits/trade-any-intent.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Trade any intent
 
-CoW Protocol allows users to express any type of trade intent on Ethereum and EVM-compatable chains, leveraging [solvers](../introduction/solvers) to execute the transactions through the most optimal route.
+CoW Protocol allows users to express any type of trade intent on Ethereum and EVM-compatible chains, leveraging [solvers](../introduction/solvers) to execute the transactions through the most optimal route.
 
 The protocol supports any order logic which includes standard market and limit orders, but also advanced order types such as [TWAP](../order-types/twap-orders). Thanks to `ERC-1271`, smart contracts can also submit intents, paving the way for the [Programmatic Order Framework](../order-types/programmatic-orders) and contracts like [Milkman](../order-types/milkman-orders). 
 


### PR DESCRIPTION
# Description

Added typo corrections to documentation for the following files:

# Changes

**docs/cow-amm/concepts/how-cow-amms-work.md**

The typo in the Getting Started with CoW AMM section.
The word "faciliate" should be correctly spelled as "facilitate."

Corrected.

**docs/cow-protocol/concepts/benefits/trade-any-intent.md**

The text contains a typo in the word "EVM-compatable", which should be corrected to "EVM-compatible".

Corrected.

# Goal

Correct grammatical errors and improve readability of the documentation.
