### PR TITLE
fix: add USDC.e to stablecoins list in Arb

### DIFF
--- a/docs/governance/fees/fees.md
+++ b/docs/governance/fees/fees.md
@@ -43,7 +43,7 @@ The purpose of this page is to let users know which fee models are active at any
 > **Eligible orders:** all market orders, limit orders, and TWAPs made on Gnosis Chain and Arbitrum One, excluding the following stablecoins, when they are traded for each other:
 >
 > - **Gnosis Chain**: sDAI, xDAI, wxDAI, EURe, GBPe, USDC, USDC.e, USDT (trading these stablecoins with each other on Gnosis Chain will incur zero fee)
-> - **Arbitrum One**: USDC, DAI, USDT, USDe, USDM, FRAX, MIM (trading these stablecoins with each other on Arbitrum One will incur zero fee)
+> - **Arbitrum One**: USDC, DAI, USDT, USDe, USDC.e, USDM, FRAX, MIM (trading these stablecoins with each other on Arbitrum One will incur zero fee)
 >
 > **Fee calculation:** volume \* 0.001
 


### PR DESCRIPTION
# Description

Fixes https://github.com/cowprotocol/cowswap/issues/5114

Added USDC.e to stablecoins list in Arbitrum in order to not add volume fee on it