### PR TITLE
feat: expose SDK reference only for the latest meta-data on the app-data project

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -94,7 +94,7 @@ const config: Config = {
       {
         id: 'app-data',
         // TypeDoc options
-        entryPoints: ['./external/app-data/src/index.ts'],
+        entryPoints: ['./external/app-data/src/latest.ts'],
         tsconfig: './external/app-data/tsconfig.json',
 
         // Plugin options


### PR DESCRIPTION
# Description

The app-data project keeps track of all all the version of the meta-data for compatibility reasons. But the latest version is always encouraged.


This PR is the companion one for the following:
- https://github.com/cowprotocol/app-data/pull/71
- https://github.com/cowprotocol/app-data/pull/73

The goal is to delete this repetition:

![image](https://github.com/user-attachments/assets/7312692d-0293-432f-a311-139e397f1196)


![image](https://github.com/user-attachments/assets/b1c3bceb-336e-4720-858e-6bb5c8d0c866)
