### PR TITLE
Add action to remind reviewer about open PRs

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -2,7 +2,6 @@ on:
   # Run every Monday at 9:00 UTC (adjust as needed)
   schedule:
     - cron: "0 9 * * 1"
-  push: #TODO remove
 
 jobs:
   send-reminder:
@@ -37,7 +36,6 @@ jobs:
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_TOKEN }}
-          #C04N05LJK54
           payload: |
-            channel: C08HBESPRLL
+            channel: C04N05LJK54
             text: "${{ steps.open_prs.outputs.message }}"

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -1,0 +1,44 @@
+on:
+  # Run every Monday at 9:00 UTC (adjust as needed)
+  schedule:
+    - cron: "0 9 * * 1"
+  push: #TODO remove
+
+jobs:
+  send-reminder:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+          
+      - name: Retrieve open (non-draft) PRs
+        id: open_prs
+        run: |
+          JSON=$(gh pr list --state open --json number,title,isDraft,url)
+          
+          # Filter out draft pull requests
+          FILTERED=$(echo "$JSON" | jq '[.[] | select(.isDraft == false)]')
+          echo "open_prs=$FILTERED" >> "$GITHUB_OUTPUT"
+  
+     - name: Create Slack message
+        id: pr_list_message
+        run: |
+          PRS='${{ steps.open_prs.outputs.open_prs }}'
+          
+          # Transform into Slack-friendly text:
+          # e.g. "• PR #123: My Pull Request Title (<URL>)"
+          MESSAGE=$(echo "$PRS" | jq -r '.[] | "• PR #\(.number): \(.title) (\(.url))"' )
+          
+          # Join them into a single multiline string
+          echo "message=Here are the open pull requests requiring review:\n$MESSAGE" >> $GITHUB_OUTPUT
+
+      - name: Send Slack message
+      - name: Post to a Slack channel
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_TOKEN }}
+          payload: |
+            channel: D0361RLSRRS #C04N05LJK54
+            text: "${{ steps.pr_list_message.outputs.message }}"

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -29,7 +29,7 @@ jobs:
           # Join them into a single multiline string
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "message<<$EOF" >> $GITHUB_OUTPUT
-          echo "Hi <@marketing-squad>, there are some open pull requests requiring review. Please work with the author to get them merged or closed:\n$MESSAGE" >> $GITHUB_OUTPUT
+          echo "Hi @marketing, there are some open pull requests requiring review. Please work with the author to get them merged or closed:\n$MESSAGE" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
 
       - name: Post to a Slack channel

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -40,5 +40,5 @@ jobs:
           #C04N05LJK54
           #"${{ steps.open_prs.outputs.message }}"
           payload: |
-            channel: D0361RLSRRS
+            channel: C08HBESPRLL
             text: "test"

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -37,6 +37,8 @@ jobs:
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_TOKEN }}
+          #C04N05LJK54
+          #"${{ steps.open_prs.outputs.message }}"
           payload: |
-            channel: D0361RLSRRS #C04N05LJK54
-            text: "test" #"${{ steps.open_prs.outputs.message }}"
+            channel: D0361RLSRRS
+            text: "test"

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -33,7 +33,6 @@ jobs:
           # Join them into a single multiline string
           echo "message=Here are the open pull requests requiring review:\n$MESSAGE" >> $GITHUB_OUTPUT
 
-      - name: Send Slack message
       - name: Post to a Slack channel
         uses: slackapi/slack-github-action@v2.0.0
         with:

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -27,7 +27,10 @@ jobs:
           MESSAGE=$(echo "$FILTERED" | jq -r '.[] | "• PR #\(.number): \(.title) (\(.url))"' )
           
           # Join them into a single multiline string
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "text<<$EOF" >> $GITHUB_OUTPUT
           echo "message=Hi @marketing-squad, there are some open pull requests requiring review. Please work with the author to get them merged or closed:\n$MESSAGE" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
 
       - name: Post to a Slack channel
         uses: slackapi/slack-github-action@v2.0.0

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -28,8 +28,8 @@ jobs:
           
           # Join them into a single multiline string
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "text<<$EOF" >> $GITHUB_OUTPUT
-          echo "message=Hi @marketing-squad, there are some open pull requests requiring review. Please work with the author to get them merged or closed:\n$MESSAGE" >> $GITHUB_OUTPUT
+          echo "message<<$EOF" >> $GITHUB_OUTPUT
+          echo "Hi @marketing-squad, there are some open pull requests requiring review. Please work with the author to get them merged or closed:\n$MESSAGE" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
 
       - name: Post to a Slack channel

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -24,12 +24,12 @@ jobs:
           
           # Transform into Slack-friendly text:
           # e.g. "• PR #123: My Pull Request Title (<URL>)"
-          MESSAGE=$(echo "$FILTERED" | jq -r '.[] | "• PR #\(.number): \(.title) (\(.url))"' )
+          MESSAGE=$(echo "$FILTERED" | jq -r '.[] | "• PR #\(.number): \(.title) (\(.url))\n"' )
           
           # Join them into a single multiline string
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "message<<$EOF" >> $GITHUB_OUTPUT
-          echo "Hi @marketing-squad, there are some open pull requests requiring review. Please work with the author to get them merged or closed:\n$MESSAGE" >> $GITHUB_OUTPUT
+          echo "Hi <@marketing-squad>, there are some open pull requests requiring review. Please work with the author to get them merged or closed:\n$MESSAGE" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
 
       - name: Post to a Slack channel

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -21,16 +21,10 @@ jobs:
           
           # Filter out draft pull requests
           FILTERED=$(echo "$JSON" | jq '[.[] | select(.isDraft == false)]')
-          echo "open_prs=$FILTERED" >> "$GITHUB_OUTPUT"
-  
-      - name: Create Slack message
-        id: pr_list_message
-        run: |
-          PRS='${{ steps.open_prs.outputs.open_prs }}'
           
           # Transform into Slack-friendly text:
           # e.g. "• PR #123: My Pull Request Title (<URL>)"
-          MESSAGE=$(echo "$PRS" | jq -r '.[] | "• PR #\(.number): \(.title) (\(.url))"' )
+          MESSAGE=$(echo "$FILTERED" | jq -r '.[] | "• PR #\(.number): \(.title) (\(.url))"' )
           
           # Join them into a single multiline string
           echo "message=Hi @marketing-squad, there are some open pull requests requiring review. Please work with the author to get them merged or closed:\n$MESSAGE" >> $GITHUB_OUTPUT

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -29,7 +29,7 @@ jobs:
           # Join them into a single multiline string
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "message<<$EOF" >> $GITHUB_OUTPUT
-          echo "Hi @marketing, there are some open pull requests requiring review. Please work with the author to get them merged or closed:\n$MESSAGE" >> $GITHUB_OUTPUT
+          echo "Hi <!subteam^S0611DEA7ED|@marketing-squad>, there are some open pull requests requiring review. Please work with the author to get them merged or closed:\n$MESSAGE" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
 
       - name: Post to a Slack channel

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -39,4 +39,4 @@ jobs:
           token: ${{ secrets.SLACK_TOKEN }}
           payload: |
             channel: D0361RLSRRS #C04N05LJK54
-            text: "${{ steps.open_prs.outputs.message }}"
+            text: "test" #"${{ steps.open_prs.outputs.message }}"

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -14,6 +14,8 @@ jobs:
           
       - name: Retrieve open (non-draft) PRs
         id: open_prs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           JSON=$(gh pr list --state open --json number,title,isDraft,url)
           
@@ -31,7 +33,7 @@ jobs:
           MESSAGE=$(echo "$PRS" | jq -r '.[] | "• PR #\(.number): \(.title) (\(.url))"' )
           
           # Join them into a single multiline string
-          echo "message=Here are the open pull requests requiring review:\n$MESSAGE" >> $GITHUB_OUTPUT
+          echo "message=Hi @marketing-squad, there are some open pull requests requiring review. Please work with the author to get them merged or closed:\n$MESSAGE" >> $GITHUB_OUTPUT
 
       - name: Post to a Slack channel
         uses: slackapi/slack-github-action@v2.0.0

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -39,4 +39,4 @@ jobs:
           token: ${{ secrets.SLACK_TOKEN }}
           payload: |
             channel: D0361RLSRRS #C04N05LJK54
-            text: "${{ steps.pr_list_message.outputs.message }}"
+            text: "${{ steps.open_prs.outputs.message }}"

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -38,7 +38,6 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_TOKEN }}
           #C04N05LJK54
-          #"${{ steps.open_prs.outputs.message }}"
           payload: |
             channel: C08HBESPRLL
-            text: "test"
+            text: "${{ steps.open_prs.outputs.message }}"

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -21,7 +21,7 @@ jobs:
           FILTERED=$(echo "$JSON" | jq '[.[] | select(.isDraft == false)]')
           echo "open_prs=$FILTERED" >> "$GITHUB_OUTPUT"
   
-     - name: Create Slack message
+      - name: Create Slack message
         id: pr_list_message
         run: |
           PRS='${{ steps.open_prs.outputs.open_prs }}'


### PR DESCRIPTION
# Description

We currently have a lot of open PRs in this repo which are either ready to be reviewed or ready to be merged but not moving forward.

This PR adds a weekly job that posts a message with a link to open PRs into slack to make it more visibile/easier for the relevant teams to move it forward.

# Changes
- [x] add a weekly github action that posts open PRs into slack
