### PR TITLE
Flashloans follow-up: rework comments

### DIFF
--- a/docs/cow-protocol/concepts/flash-loans/integrators.md
+++ b/docs/cow-protocol/concepts/flash-loans/integrators.md
@@ -19,13 +19,13 @@ It is important to ensure that the flash loan gas overhead is added to the slipp
 }
 ````
 
-- **lender (optional):** the contract that could be used to borrow the funds from. For example `0x60744434d6339a6B27d73d9Eda62b6F66a0a04FA` for any `ERC-3156` compliant lender contract, or `0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2` for AAVE. If the value is not provided the solver will choose a sensible default.
+- **lender:** the contract that could be used to borrow the funds from. For example `0x60744434d6339a6B27d73d9Eda62b6F66a0a04FA` for any `ERC-3156` compliant lender contract, or `0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2` for AAVE. 
 - **borrower (optional):** who should receive the borrowed tokens. If no value is provided, the order owner's address will be used as the borrower.
 - **token:** the token that needs to get borrowed.
 - **amount:** how many atoms of the token need to get borrowed (e.g., 1 `WETH` would be 10¹⁸).
 
 # How a lender protocol can be compatible with CoW Protocol
 
-If the lender protocol rely on direct repayment from the borrower through `transferFrom`, then the lender protocol could implement the borrower functions as in [Aave Borrower](https://github.com/cowprotocol/flash-loan-router/blob/main/src/AaveBorrower.sol) or in [ERC-3156 wrapper](https://github.com/cowprotocol/flash-loan-router/blob/main/src/ERC3156Borrower.sol).
-
 If the lender supports ERC-3156 then there is no extra smart-contract work needed.
+
+If the lender protocol rely on direct repayment from the borrower through `transferFrom`, then the lender protocol could implement the borrower functions as in [Aave Borrower](https://github.com/cowprotocol/flash-loan-router/blob/main/src/AaveBorrower.sol) or in [ERC-3156 wrapper](https://github.com/cowprotocol/flash-loan-router/blob/main/src/ERC3156Borrower.sol).

--- a/docs/cow-protocol/concepts/flash-loans/integrators.md
+++ b/docs/cow-protocol/concepts/flash-loans/integrators.md
@@ -19,9 +19,13 @@ It is important to ensure that the flash loan gas overhead is added to the slipp
 }
 ````
 
-- **lender (optional):** the contract that could be used to borrow the funds from. For example `0x60744434d6339a6B27d73d9Eda62b6F66a0a04FA` for Maker DAO, or `0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2` for AAVE.
-- **borrower (optional):** who should receive the borrowed tokens.
+- **lender (optional):** the contract that could be used to borrow the funds from. For example `0x60744434d6339a6B27d73d9Eda62b6F66a0a04FA` for Maker DAO, or `0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2` for AAVE. If the value is not provided the solver will choose a sensible default.
+- **borrower (optional):** who should receive the borrowed tokens. If no value is provided, the order owner's address will be used as the borrower.
 - **token:** the token that needs to get borrowed.
 - **amount:** how many atoms of the token need to get borrowed (e.g., 1 `WETH` would be 10¹⁸).
 
-If optional values were not provided the solver will choose sensible defaults.
+# How a lender protocol can be compatible with CoW Protocol
+
+If the lender protocol rely on direct repayment from the borrower through `transferFrom`, then the lender protocol could implement the borrower functions as in [Aave Borrower](https://github.com/cowprotocol/flash-loan-router/blob/main/src/AaveBorrower.sol) or in [ERC-3156 wrapper](https://github.com/cowprotocol/flash-loan-router/blob/main/src/ERC3156Borrower.sol).
+
+If the lender supports ERC-3156 then there is no extra smart-contract work needed.

--- a/docs/cow-protocol/concepts/flash-loans/integrators.md
+++ b/docs/cow-protocol/concepts/flash-loans/integrators.md
@@ -19,7 +19,7 @@ It is important to ensure that the flash loan gas overhead is added to the slipp
 }
 ````
 
-- **lender (optional):** the contract that could be used to borrow the funds from. For example `0x60744434d6339a6B27d73d9Eda62b6F66a0a04FA` for Maker DAO, or `0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2` for AAVE. If the value is not provided the solver will choose a sensible default.
+- **lender (optional):** the contract that could be used to borrow the funds from. For example `0x60744434d6339a6B27d73d9Eda62b6F66a0a04FA` for any `ERC-3156` compliant lender contract, or `0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2` for AAVE. If the value is not provided the solver will choose a sensible default.
 - **borrower (optional):** who should receive the borrowed tokens. If no value is provided, the order owner's address will be used as the borrower.
 - **token:** the token that needs to get borrowed.
 - **amount:** how many atoms of the token need to get borrowed (e.g., 1 `WETH` would be 10¹⁸).

--- a/docs/cow-protocol/concepts/order-types/pay-debt-flash-loans.md
+++ b/docs/cow-protocol/concepts/order-types/pay-debt-flash-loans.md
@@ -25,14 +25,14 @@ When it comes to repaying debt, the approach depends on the lender's contract te
 
 #### Lender allows a third-party to initiate the transfer of collateral tokens
 
-In this case, the user can sign a pre-hook that deploys a [COWShed](https://github.com/cowdao-grants/cow-shed) to repay the debt using flash-loaned tokens. `COWShed` is a user owned ERC1967 proxy deployed at a deterministic address. This deterministic deployment allows users to set the proxy address as the receiver for cowswap orders with pre/post-hooks. The user signs a EIP712 message for the pre/post-hooks which gets validated and only user signed hooks are executed on the user's proxy. This allows users to confidently perform permissioned actions in the hooks like:
+In this case, the user can sign a pre-hook that deploys a [COWShed](https://github.com/cowdao-grants/cow-shed) to repay the debt using flash-loaned tokens. `COWShed` is a user owned ERC-1967 proxy deployed at a deterministic address. This deterministic deployment allows users to set the proxy address as the receiver for cowswap orders with pre/post-hooks. The user signs a EIP-712 message for the pre/post-hooks which gets validated. Only user signed hooks are executed on the user's proxy. This allows users to confidently perform permissioned actions in the hooks such as:
 
 - transferring assets from the proxy to someone else.
 - use the proxy to add collateral or repay debt on a maker CDP or an AAVE debt position, etc.
 
 In order to create the `COWShed`, the user can use the [COWShed SDK](https://github.com/cowprotocol/cow-sdk/tree/main/src/cow-shed).
 
-Then, the underlying user order is then solely for repaying the required flash loan. Since the repayment is handled via `COWShed`, the user can be either an EOA (Externally Owned Account) or a contract (e.g., a SAFE wallet).
+The underlying user order is only used to repay the required flash loan. Since the repayment is handled via `COWShed`, the user can be either an EOA (Externally Owned Account) or a contract (e.g., a SAFE wallet).
 
 #### Lender does not allow a third-party to initiate the transfer of collateral tokens
 

--- a/docs/cow-protocol/concepts/order-types/pay-debt-flash-loans.md
+++ b/docs/cow-protocol/concepts/order-types/pay-debt-flash-loans.md
@@ -25,7 +25,14 @@ When it comes to repaying debt, the approach depends on the lender's contract te
 
 #### Lender allows a third-party to initiate the transfer of collateral tokens
 
-In this case, the user can sign a pre-hook that deploys a `cowshed` to repay the debt using flash-loaned tokens. The underlying user order is then solely for repaying the required flash loan. Since the repayment is handled via `cowshed`, the user can be either an EOA (Externally Owned Account) or a contract (e.g., a SAFE wallet).
+In this case, the user can sign a pre-hook that deploys a [COWShed](https://github.com/cowdao-grants/cow-shed) to repay the debt using flash-loaned tokens. `COWShed` is a user owned ERC1967 proxy deployed at a deterministic address. This deterministic deployment allows users to set the proxy address as the receiver for cowswap orders with pre/post-hooks. The user signs a EIP712 message for the pre/post-hooks which gets validated and only user signed hooks are executed on the user's proxy. This allows users to confidently perform permissioned actions in the hooks like:
+
+- transferring assets from the proxy to someone else.
+- use the proxy to add collateral or repay debt on a maker CDP or an AAVE debt position, etc.
+
+In order to create the `COWShed`, the user can use the [COWShed SDK](https://github.com/cowprotocol/cow-sdk/tree/main/src/cow-shed).
+
+Then, the underlying user order is then solely for repaying the required flash loan. Since the repayment is handled via `COWShed`, the user can be either an EOA (Externally Owned Account) or a contract (e.g., a SAFE wallet).
 
 #### Lender does not allow a third-party to initiate the transfer of collateral tokens
 

--- a/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
+++ b/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
@@ -128,6 +128,45 @@ sequenceDiagram
     deactivate Driver
 ```
 
+#### Flash Loans Encoding
+
+If a solver decides to encode the transaction without the help of the reference driver, the solver must call the `IFlashLoanRouter` contract's [flashLoanAndSettle](../../../reference/contracts/periphery/flash-loans.md#flashloanandsettle) function instead of the settlement contract's [settle](../../../reference/contracts/core/settlement.md#settle) function. The solver must provide all necessary flash loan inputs for the settlement, as well as the settle calldata, which will be executed within the same context by the `IFlashLoanRouter` contract. The `IFlashLoanRouter` contract will then request the specified flash loans and, once received, execute the settlement as instructed.
+
+The entry point to the router contract ([IFlashLoanRouter](../../../reference/contracts/periphery/flash-loans.md#iflashloanrouter-contract)) is the function `flashLoanAndSettle`.
+It takes a list of loans with the following entries for each loan:
+
+- The loaned amount and ERC-20 token.
+- The flash-loan lender (e.g., Balancer, Aave, Maker, ...).
+- The _borrower_, which is an adapter contract that makes the specific lender implementation compatible with the router.
+
+It also takes the exact call data for a call to `settle`.
+The flash-loan router is a solver for CoW Protocol and calls `settle` directly once the flash loans have been obtained.
+Only CoW-Protocol solvers can call this function.
+
+Tokens and lenders are external contracts, while the router and each specific borrowers are dedicated contract implemented by CoW Protocol.
+
+The borrowers are the contracts that are called back by the lender once the flash loan is initiated; they are the contracts that receive the flash-loan proceeds and that are eventually responsible to repay the loan.
+
+The only way to move funds out of a borrower is through an ERC-20 approval for some spender.
+Approvals can be set by calling the [approve](../../../reference/contracts/periphery/flash-loans.md#approve) function on the borrower contract ([IBorrower](../../../reference/contracts/periphery/flash-loans.md#iborrower-contract)) from the context of a settlement.
+For safe operations, like an approval for the settlement contract to spend the funds of the borrower, it's enough to set the approval once for an unlimited amount and reuse the same approval in future settlements.
+
+At the start of the settlement, it's expected that the loaned funds are transferred from the borrowers to where they are needed. For example, this can be the settlement contract itself, or the address of a user who wants to use the loan to retrieve the collateral needed to avoid liquidations.
+
+In general, solvers have full flexibility in deciding how loaned funds are allocated.
+
+The settlement is also responsible for repaying the flash loans.
+The specific repayment mechanism depends on the lender, but a common process is having the settlement contract send back the borrowed funds to the borrower and set an approval to the lender for spending the funds of the borrower: then the lender is going to pull back the funds with an ERC-20 `transferFrom` after the settlement is terminated.
+Inability to pay for a flash loan will most likely be met by a reverting transaction.
+The flash loans must be executed before any pre-interaction, so the funds are available before the pre-interactions are executed.
+
+For each flash loan, the following encoding has to be added:
+
+- Allow settlement contract to pull borrowed tokens from flash loan wrapper.
+- Transfer tokens from flash loan wrapper to user (i.e. borrower).
+- Since the order receiver is expected to be the settlement contract, it is needed to transfer the tokens from the settlement contract to the flash loan wrapper.
+- Allow flash loan lender to take tokens from wrapper contract
+
 ## Considerations
 
 As you can see the driver has many responsibilities and discussing all of them in detail would be beyond the scope of this documentation but it's worth mentioning one guiding principle that applies to most of them: 

--- a/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
+++ b/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
@@ -157,7 +157,7 @@ In general, solvers have full flexibility in deciding how loaned funds are alloc
 
 The settlement is also responsible for repaying the flash loans.
 The specific repayment mechanism depends on the lender, but a common process is having the settlement contract send back the borrowed funds to the borrower and set an approval to the lender for spending the funds of the borrower: then the lender is going to pull back the funds with an ERC-20 `transferFrom` after the settlement is terminated.
-Inability to pay for a flash loan will most likely be met by a reverting transaction.
+Inability to pay for a flash loan will result in a reverting transaction.
 The flash loans must be executed before any pre-interaction, so the funds are available before the pre-interactions are executed.
 
 For each flash loan, the following encoding has to be added:

--- a/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
+++ b/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
@@ -165,7 +165,7 @@ For each flash loan, the following encoding has to be added:
 - Allow settlement contract to pull borrowed tokens from flash loan wrapper.
 - Transfer tokens from flash loan wrapper to user (i.e. borrower).
 - Since the order receiver is expected to be the settlement contract, it is needed to transfer the tokens from the settlement contract to the flash loan wrapper.
-- Allow flash loan lender to take tokens from wrapper contract
+- Allow flash loan lender to take tokens from wrapper contract.
 
 ## Considerations
 

--- a/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
+++ b/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
@@ -143,11 +143,11 @@ It also takes the exact call data for a call to `settle`.
 The flash-loan router is a solver for CoW Protocol and calls `settle` directly once the flash loans have been obtained.
 Only CoW-Protocol solvers can call this function.
 
-Tokens and lenders are external contracts, while the router and each specific borrowers are dedicated contract implemented by CoW Protocol.
+Tokens and lenders are external contracts, while the router and borrowers have a dedicated contract implemented by CoW Protocol.
 
 The borrowers are the contracts that are called back by the lender once the flash loan is initiated; they are the contracts that receive the flash-loan proceeds and that are eventually responsible to repay the loan.
 
-The only way to move funds out of a borrower is through an ERC-20 approval for some spender.
+The only way to move funds out of a borrower is through an ERC-20 approval transaction from the spender.
 Approvals can be set by calling the [approve](../../../reference/contracts/periphery/flash-loans.md#approve) function on the borrower contract ([IBorrower](../../../reference/contracts/periphery/flash-loans.md#iborrower-contract)) from the context of a settlement.
 For safe operations, like an approval for the settlement contract to spend the funds of the borrower, it's enough to set the approval once for an unlimited amount and reuse the same approval in future settlements.
 

--- a/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
+++ b/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
@@ -139,11 +139,9 @@ It takes a list of loans with the following entries for each loan:
 - The flash-loan lender (e.g., Balancer, Aave, Maker, ...).
 - The _borrower_, which is an adapter contract that makes the specific lender implementation compatible with the router.
 
+Only CoW-Protocol solvers can call this function.
 It also takes the exact call data for a call to `settle`.
 The flash-loan router is a solver for CoW Protocol and calls `settle` directly once the flash loans have been obtained.
-Only CoW-Protocol solvers can call this function.
-
-Tokens and lenders are external contracts, while the router and borrowers have a dedicated contract implemented by CoW Protocol.
 
 The borrowers are the contracts that are called back by the lender once the flash loan is initiated; they are the contracts that receive the flash-loan proceeds and that are eventually responsible to repay the loan.
 
@@ -157,15 +155,12 @@ In general, solvers have full flexibility in deciding how loaned funds are alloc
 
 The settlement is also responsible for repaying the flash loans.
 The specific repayment mechanism depends on the lender, but a common process is having the settlement contract send back the borrowed funds to the borrower and set an approval to the lender for spending the funds of the borrower: then the lender is going to pull back the funds with an ERC-20 `transferFrom` after the settlement is terminated.
-Inability to pay for a flash loan will result in a reverting transaction.
-The flash loans must be executed before any pre-interaction, so the funds are available before the pre-interactions are executed.
 
 For each flash loan, the following encoding has to be added:
 
 - Allow settlement contract to pull borrowed tokens from flash loan wrapper.
 - Transfer tokens from flash loan wrapper to user (i.e. borrower).
-- Since the order receiver is expected to be the settlement contract, it is needed to transfer the tokens from the settlement contract to the flash loan wrapper.
-- Allow flash loan lender to take tokens from wrapper contract.
+- Repayment: Repay the borrowed tokens. For example, the tokens can be transferred from the settlement contract to the flash loan wrapper. Then, the flash loan wrapper can approve the flash loan lender to withdraw the tokens directly from it.
 
 ## Considerations
 

--- a/docs/cow-protocol/tutorials/arbitrate/solver/solver-engine.md
+++ b/docs/cow-protocol/tutorials/arbitrate/solver/solver-engine.md
@@ -107,34 +107,6 @@ The settlement contract will receive the swap order funds, but it is the solverâ
 
 The reference driver facilitates this process by pulling funds from the `IFlashLoanRouter` contract and transferring them to the user, so they can be used for the order swap. Since the settlement contract is the recipient of the swap, the driver must then move the funds back to the `IFlashLoanRouter` contract, ensuring that the flash loan lender can retrieve the required repayment from it. If a solver chooses to implement a custom driver, they are responsible for managing this behavior as they deem appropriate.
 
-If a solver decides to encode the transaction without the help of the reference driver, the solver must call the `IFlashLoanRouter` contract's [flashLoanAndSettle](../../../reference/contracts/periphery/flash-loans.md#flashloanandsettle) function instead of the settlement contract's [settle](../../../reference/contracts/core/settlement.md#settle) function. The solver must provide all necessary flash loan inputs for the settlement, as well as the settle calldata, which will be executed within the same context by the `IFlashLoanRouter` contract. The `IFlashLoanRouter` contract will then request the specified flash loans and, once received, execute the settlement as instructed.
-
-The entry point to the router contract ([IFlashLoanRouter](../../../reference/contracts/periphery/flash-loans.md#iflashloanrouter-contract)) is the function `flashLoanAndSettle`.
-It takes a list of loans with the following entries for each loan:
-
-- The loaned amount and ERC-20 token.
-- The flash-loan lender (e.g., Balancer, Aave, Maker, ...).
-- The _borrower_, which is an adapter contract that makes the specific lender implementation compatible with the router.
-
-It also takes the exact call data for a call to `settle`.
-The flash-loan router is a solver for CoW Protocol and calls `settle` directly once the flash loans have been obtained.
-Only CoW-Protocol solvers can call this function.
-
-Tokens and lenders are external contracts, while the router and each specific borrowers are dedicated contract implemented by CoW Protocol.
-
-The borrowers are the contracts that are called back by the lender once the flash loan is initiated; they are the contracts that receive the flash-loan proceeds and that are eventually responsible to repay the loan.
-
-The only way to move funds out of a borrower is through an ERC-20 approval for some spender.
-Approvals can be set by calling the [approve](../../../reference/contracts/periphery/flash-loans.md#approve) function on the borrower contract ([IBorrower](../../../reference/contracts/periphery/flash-loans.md#iborrower-contract)) from the context of a settlement.
-For safe operations, like an approval for the settlement contract to spend the funds of the borrower, it's enough to set the approval once for an unlimited amount and reuse the same approval in future settlements.
-
-At the start of the settlement, it's expected that the loaned funds are transferred from the borrowers to where they are needed. For example, this can be the settlement contract itself, or the address of a user who wants to use the loan to retrieve the collateral needed to avoid liquidations.
-In general, solvers have full flexibility in deciding how loaned funds are allocated.
-
-The settlement is also responsible for repaying the flash loans.
-The specific repayment mechanism depends on the lender, but a common process is having the settlement contract send back the borrowed funds to the borrower and set an approval to the lender for spending the funds of the borrower: then the lender is going to pull back the funds with an ERC-20 `transferFrom` after the settlement is terminated.
-Inability to pay for a flash loan will most likely be met by a reverting transaction.
-
 We support the following flash-loan lenders:
 
 - Any lender that is compatible with [ERC-3156](https://eips.ethereum.org/EIPS/eip-3156) interface (for example [Maker](https://docs.makerdao.com/smart-contract-modules/flash-mint-module)).


### PR DESCRIPTION
# Description

Addressing comments from https://github.com/cowprotocol/docs/pull/451


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified the usage and default behavior of "lender" and "borrower" fields in flash loan order documentation.
  - Added a section explaining how lender protocols can be compatible with CoW Protocol, including integration strategies for ERC-3156 and non-ERC-3156 lenders.
  - Expanded details on the COWShed proxy in pay-debt flash loan scenarios, including deployment, permissions, and usage examples.
  - Introduced a comprehensive guide on encoding flash loan transactions for solvers, outlining contract interactions and encoding steps.
  - Removed redundant or relocated content about flash loan transaction encoding from the solver engine tutorial.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->