### PR TITLE
Remove Arb1 from volume fee

### DIFF
--- a/docs/governance/fees/fees.md
+++ b/docs/governance/fees/fees.md
@@ -33,18 +33,16 @@ The purpose of this page is to let users know which fee models are active at any
 >
 > **Fee calculation:** quote improvement \* 0.5 **OR** volume \* 0.01 [whichever number is lower]
 
-### Volume fee on Gnosis Chain and Arbitrum One orders (excluding token pairs with correlated prices)
+### Volume fee on Gnosis Chain orders (excluding token pairs with correlated prices)
 
 [//]: # 'If updating the list of stable coins, do not forget to update the actual code where this is handled on CoW Swap'
 [//]: # 'https://github.com/cowprotocol/cowswap/blob/develop/libs/common-const/src/tokens.ts#L293-L302'
 
 > **Definition:** 10 basis points on the total volume of the order
 >
-> **Eligible orders:** all market orders, limit orders, and TWAPs made on Gnosis Chain and Arbitrum One, excluding tokens with correlated prices when traded for each other.
+> **Eligible orders:** all market orders, limit orders, and TWAPs made on Gnosis Chain, excluding tokens with correlated prices when traded for each other.
 >
 > **Fee calculation:** volume \* 0.001
-
-At first, only a subset of Arbitrum One orders will have the fee applied.
 
 :::note
 

--- a/docs/governance/fees/fees.md
+++ b/docs/governance/fees/fees.md
@@ -44,6 +44,7 @@ The purpose of this page is to let users know which fee models are active at any
 >
 > **Fee calculation:** volume \* 0.001
 
+
 :::note
 
 **Surplus** is defined as the difference between the executed price and the minimum execution price for an order


### PR DESCRIPTION
# Description

The PR updates Fees section as volume fee is no longer charged on Arb1. See more details [here](https://cowservices.slack.com/archives/C05N1FNP3MX/p1742315781372079?thread_ts=1736758885.400219&cid=C05N1FNP3MX). 

**To test:** 
1. Open[ Fees page](https://docs-git-no-volume-fee-on-arb1-cowswap.vercel.app/governance/fees#volume-fee-on-gnosis-chain-orders-excluding-token-pairs-with-correlated-prices)
2. Verify Volume fee section

**ER**: Arb1 should not be mentioned there. 