### PR TITLE
fix: incorrect token in flashloan tutorial

### DIFF
--- a/docs/cow-protocol/tutorials/cow-swap/flash-loans.mdx
+++ b/docs/cow-protocol/tutorials/cow-swap/flash-loans.mdx
@@ -17,7 +17,7 @@ The setup for the flash loan example is as follows:
 * The necessary `ERC-20` approvals are set in the wallet:
     * The collateral token (USDC) is approved for CoW's Vault Relayer contract to facilitate the trade.
     * The borrowed token (USDT) is approved for the Aave pool contract to enable debt repayment.
-* The Safe must have a non-zero balance of the order's buy token to pass CoW Swap order validation, which serves as a spam protection measure.
+* The Safe must have a non-zero balance of the order's sell token (USDC in this case) to pass CoW Swap order validation, which serves as a spam protection measure.
 
 The order itself intends to:
 1. Request a flash loan to Aave of 5,000 USDT.


### PR DESCRIPTION
# Description

There was a mistake on the flashloan tutorial created on https://github.com/cowprotocol/docs/pull/465

The safe needs to have a balance of the **sell** token, not the buy token as written. In the example case it would be USDC since that is the collateral token we want to sell with our order.
