### PR TITLE
Update text how to enable hooks dApps

### DIFF
--- a/docs/cow-protocol/tutorials/hook-dapp/hook-dapp.md
+++ b/docs/cow-protocol/tutorials/hook-dapp/hook-dapp.md
@@ -28,8 +28,8 @@ In order to add a custom hook, you need to:
 
 :::note
 
-> CoW Hooks are still under development!   
-> But you can test it by switching "Enable hooks" toggle ON in the Swap settings. 
+CoW Hooks are still under development!   
+But you can test it by switching "Enable hooks" toggle ON in the Swap settings. 
 
 :::
 

--- a/docs/cow-protocol/tutorials/hook-dapp/hook-dapp.md
+++ b/docs/cow-protocol/tutorials/hook-dapp/hook-dapp.md
@@ -24,10 +24,12 @@ In order to add a custom hook, you need to:
 - Go to "My Custom Hooks" tab
 - Paste a URL of the hook dApp
 
+<img alt="Demo" src="/img/tutorials/hooks-store-custom-hooks.png" width="300"/>
+
 > CoW Hooks are still under development!   
 > But you can test it by switching "Enable hooks" toggle ON in the Swap settings. 
 
-<img alt="Demo" src="/img/tutorials/hooks-store-custom-hooks.png" width="300"/>
+
 
 ## How to develop CoW Hook dApps
 

--- a/docs/cow-protocol/tutorials/hook-dapp/hook-dapp.md
+++ b/docs/cow-protocol/tutorials/hook-dapp/hook-dapp.md
@@ -24,8 +24,8 @@ In order to add a custom hook, you need to:
 - Go to "My Custom Hooks" tab
 - Paste a URL of the hook dApp
 
-> CoW Hooks are still under development! The feature is not enabled in tbe production environment just yet.  
-> You can test CoW Hooks at <https://barn.cow.fi>.
+> CoW Hooks are still under development!   
+> But you can test it by switching "Enable hooks" toggle ON in the Swap settings. 
 
 <img alt="Demo" src="/img/tutorials/hooks-store-custom-hooks.png" width="300"/>
 

--- a/docs/cow-protocol/tutorials/hook-dapp/hook-dapp.md
+++ b/docs/cow-protocol/tutorials/hook-dapp/hook-dapp.md
@@ -26,6 +26,7 @@ In order to add a custom hook, you need to:
 
 <img alt="Demo" src="/img/tutorials/hooks-store-custom-hooks.png" width="300"/>
 
+
 > CoW Hooks are still under development!   
 > But you can test it by switching "Enable hooks" toggle ON in the Swap settings. 
 

--- a/docs/cow-protocol/tutorials/hook-dapp/hook-dapp.md
+++ b/docs/cow-protocol/tutorials/hook-dapp/hook-dapp.md
@@ -26,11 +26,12 @@ In order to add a custom hook, you need to:
 
 <img alt="Demo" src="/img/tutorials/hooks-store-custom-hooks.png" width="300"/>
 
+:::note
 
 > CoW Hooks are still under development!   
 > But you can test it by switching "Enable hooks" toggle ON in the Swap settings. 
 
-
+:::
 
 ## How to develop CoW Hook dApps
 


### PR DESCRIPTION
Hooks store is on Prod. 
We should let users know how to enable hooks.

**To test:** 
Open https://docs-git-note-how-to-enable-hooks-cowswap.vercel.app/cow-protocol/tutorials/hook-dapp#technical-specification
Check this note: 
![image](https://github.com/user-attachments/assets/0b8d0743-d2ee-4c4c-a0ff-f6784bed509f)


