### PR TITLE
docs: fix link to label good first issue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,4 +29,4 @@ Any non-trivial documentation must be first discussed with the maintainers in an
 
 When opening the pull request you will be presented with a template and a series of instructions. Read through it carefully and follow all the steps. Expect a review and feedback from the maintainers afterwards.
 
-If you're looking for a good place to start, look for issues labelled ["good first issue"](./labels/good%20first%20issue)!
+If you're looking for a good place to start, look for issues labelled ["good first issue"](https://github.com/cowprotocol/docs/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)!


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the "good first issue" link in the contributing guidelines to direct users to the correct GitHub issues page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->