### PR TITLE
feat: update CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -10,6 +10,18 @@ jobs:
   cla:
     runs-on: ubuntu-latest
     steps:
+      - name: 'Get Team Members'
+        id: team
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const members = await github.paginate(
+              github.rest.orgs.listMembers,
+              { org: "cowprotocol" },
+            );
+            return members.map(m => m.login).join(",");
+      
       - name: "CLA Assistant"
         if: ((github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target') && github.repository_owner == 'cowprotocol' && github.repository != 'cowprotocol/cla'
         uses: contributor-assistant/github-action@v2.6.1
@@ -19,4 +31,4 @@ jobs:
           branch: 'cla-signatures'
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/cowprotocol/cla/blob/main/CLA.md'
-          allowlist: '*[bot]'
+          allowlist: '${{ steps.team.outputs.result }},*[bot],lint-action,dependabot,mergify'


### PR DESCRIPTION
# Description

Update CLA allowlist, adding team members, lint-action, dependabot and mergify


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the contributor license agreement (CLA) workflow to automatically include all current organization members in the allowlist for CLA checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->