### PR TITLE
fix: remove duplicated footnotes from Governance - Token page

### DIFF
--- a/docs/governance/token.md
+++ b/docs/governance/token.md
@@ -21,7 +21,7 @@ At the core of CoW Protocol lies the COW token, which serves as a governance tok
 
 [^bridgedTokens]:
     These contracts were not developed nor deployed by CoW DAO, however, they are the bridged versions of the canonical token from Ethereum, using the official bridges.
-    [Omni bridge](https://gnosisscan.io/address/0xf6A78083ca3e2a662D6dd1703c939c8aCE2e268d#code) for Gnosis Chain, [Arbitrum One bridge](https://arbiscan.io/address/0x09e9222e96e7b4ae2a407b98d48e330053351eee#code) for Arbitrum one, [Superbridge](https://basescan.org/tx/0xf76a915b7db279a4e559dbc382462e23cb63615f3d3a87ddf36bd96cedf4ca56) for Base, and [Polygon One Bridge](https://portal.polygon.technology/bridge) for Polygon.
+    [Omni bridge](https://gnosisscan.io/address/0xf6A78083ca3e2a662D6dd1703c939c8aCE2e268d#code) for Gnosis Chain, [Arbitrum One bridge](https://arbiscan.io/address/0x09e9222e96e7b4ae2a407b98d48e330053351eee#code) for Arbitrum one, [Superbridge](https://basescan.org/tx/0xf76a915b7db279a4e559dbc382462e23cb63615f3d3a87ddf36bd96cedf4ca56) for Base, and [Polygon Bridge](https://portal.polygon.technology/bridge) for Polygon.
 
 #### `vCOW` - Vesting token
 

--- a/docs/governance/token.md
+++ b/docs/governance/token.md
@@ -21,7 +21,7 @@ At the core of CoW Protocol lies the COW token, which serves as a governance tok
 
 [^bridgedTokens]:
     These contracts were not developed nor deployed by CoW DAO, however, they are the bridged versions of the canonical token from Ethereum, using the official bridges.
-    [Omni bridge](https://gnosisscan.io/address/0xf6A78083ca3e2a662D6dd1703c939c8aCE2e268d#code) for Gnosis Chain, [Arbitrum One bridge](https://arbiscan.io/address/0x09e9222e96e7b4ae2a407b98d48e330053351eee#code) for Arbitrum one and [Superbridge](https://basescan.org/tx/0xf76a915b7db279a4e559dbc382462e23cb63615f3d3a87ddf36bd96cedf4ca56) for Base.
+    [Omni bridge](https://gnosisscan.io/address/0xf6A78083ca3e2a662D6dd1703c939c8aCE2e268d#code) for Gnosis Chain, [Arbitrum One bridge](https://arbiscan.io/address/0x09e9222e96e7b4ae2a407b98d48e330053351eee#code) for Arbitrum one, [Superbridge](https://basescan.org/tx/0xf76a915b7db279a4e559dbc382462e23cb63615f3d3a87ddf36bd96cedf4ca56) for Base, and [Polygon One Bridge](https://portal.polygon.technology/bridge) for Polygon.
 
 #### `vCOW` - Vesting token
 

--- a/docs/governance/token.md
+++ b/docs/governance/token.md
@@ -137,7 +137,3 @@ The DAO treasury holds a significant portion of the token supply for long-term g
   
 
 Even if the DAO eventually allocates these tokens (via votes, incentive programs, etc.), until that happens, they're considered non-circulating.
-
-## Footnotes
-
-These contracts were not developed nor deployed by CoW DAO, however, they are the bridged versions of the canonical token from Ethereum, using the official bridges. [Omni bridge](https://gnosisscan.io/address/0xf6A78083ca3e2a662D6dd1703c939c8aCE2e268d#code) for Gnosis Chain, [Arbitrum One bridge](https://arbiscan.io/address/0x09e9222e96e7b4ae2a407b98d48e330053351eee#code) for Arbitrum one and [Superbridge](https://basescan.org/tx/0xf76a915b7db279a4e559dbc382462e23cb63615f3d3a87ddf36bd96cedf4ca56) for Base. [↩](https://docs.cow.fi/governance/token#user-content-fnref-bridgedtokens)  [↩2](https://docs.cow.fi/governance/token#user-content-fnref-bridgedtokens-2)  [↩3](https://docs.cow.fi/governance/token#user-content-fnref-bridgedtokens-3)


### PR DESCRIPTION
# Description

- Remove duplicate footnotes
- Add Polygon Bridge to the footnotes

![Screenshot 2025-07-03 at 09 57 33](https://github.com/user-attachments/assets/969435e7-9bbf-4230-b783-2e94cc4abf3f)

# Test

Go to the [Token page](https://docs-git-fix-governance-token-footnotes-cowswap.vercel.app/governance/token), click on any superscript link and the page should scroll down to the footnotes.

![Screenshot 2025-07-03 at 09 59 00](https://github.com/user-attachments/assets/bea89b41-9e0b-4f9c-ac23-6868641fc5f3)

- [ ] Only one footnote block is visible
- [ ] Polygon Bridge is added to the footnotes, and it links to [Polygon Bridge](https://portal.polygon.technology/bridge)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated information to include the Polygon Bridge as an official bridge for the COW token on Polygon.
  * Expanded footnote to mention all supported bridges.
  * Removed a redundant footnotes section for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->