### PR TITLE
Update trampoline

### DIFF
--- a/docs/cow-protocol/reference/contracts/periphery/README.mdx
+++ b/docs/cow-protocol/reference/contracts/periphery/README.mdx
@@ -65,6 +65,6 @@ CoW Protocol contracts are generally deployed to the same addresses on their res
 
 | Network | Address |
 |---------|---------|
-| [Mainnet](https://etherscan.io/address/0xe84dcd8587287b997f51299430a396ad03aaec06) | `0xe84dcd8587287b997f51299430a396ad03aaec06` |
+| [Mainnet](https://etherscan.io/address/0xe84dcd8587287b997f51299430a396ad03aaec06) | `0xe84DCd8587287B997F51299430A396AD03aAEC06` |
 | [Gnosis chain](https://gnosisscan.io/address/0xCA51403B524dF7dA6f9D6BFc64895AD833b5d711) | `0xCA51403B524dF7dA6f9D6BFc64895AD833b5d711` |
 | [Base](https://basescan.org/address/0x96dddac514d0799e34e3f642c5006852ad24cd68) | `0x96ddDAC514d0799e34e3F642c5006852aD24CD68` |

--- a/docs/cow-protocol/reference/contracts/periphery/README.mdx
+++ b/docs/cow-protocol/reference/contracts/periphery/README.mdx
@@ -27,15 +27,19 @@ CoW Protocol contracts are generally deployed to the same addresses on their res
 **Upgradeable**: No ❎  
 **GitHub**: [HooksTrampoline.sol](https://github.com/cowprotocol/hooks-trampoline/blob/main/src/HooksTrampoline.sol)
 
-**Address**: `0x01DcB88678aedD0C4cC9552B20F4718550250574`
+**Address**: `0x60bf78233f48ec42ee3f101b9a05ec7878728006`
 
 **Networks**: 
-[Mainnet](https://etherscan.io/address/0x01DcB88678aedD0C4cC9552B20F4718550250574), 
-[Gnosis chain](https://gnosisscan.io/address/0x01DcB88678aedD0C4cC9552B20F4718550250574), 
-[Arbitrum one](https://arbiscan.io/address/0x01DcB88678aedD0C4cC9552B20F4718550250574), 
-[Base](https://basescan.org/address/0x01DcB88678aedD0C4cC9552B20F4718550250574), 
-[Avalanche](https://snowscan.xyz/address/0x01DcB88678aedD0C4cC9552B20F4718550250574), 
-[Polygon](https://polygonscan.com/address/0x01DcB88678aedD0C4cC9552B20F4718550250574)
+[Mainnet](https://etherscan.io/address/0x60bf78233f48ec42ee3f101b9a05ec7878728006), 
+[Sepolia](https://sepolia.etherscan.io/address/0x60bf78233f48ec42ee3f101b9a05ec7878728006), 
+[Gnosis chain](https://gnosisscan.io/address/0x60bf78233f48ec42ee3f101b9a05ec7878728006), 
+[Base](https://basescan.org/address/0x60bf78233f48ec42ee3f101b9a05ec7878728006), 
+[Arbitrum one](https://arbiscan.io/address/0x60bf78233f48ec42ee3f101b9a05ec7878728006), 
+[Avalanche](https://snowscan.xyz/address/0x60bf78233f48ec42ee3f101b9a05ec7878728006), 
+[Polygon](https://polygonscan.com/address/0x60bf78233f48ec42ee3f101b9a05ec7878728006), 
+[Binance](https://bscscan.com/address/0x60bf78233f48ec42ee3f101b9a05ec7878728006), 
+[Optimism](https://optimistic.etherscan.io/address/0x60bf78233f48ec42ee3f101b9a05ec7878728006), 
+[Lens](https://explorer.lens.xyz/address/0x60bf78233f48ec42ee3f101b9a05ec7878728006)
 
 ### ComposableCoW
 

--- a/docs/cow-protocol/reference/contracts/periphery/README.mdx
+++ b/docs/cow-protocol/reference/contracts/periphery/README.mdx
@@ -10,9 +10,57 @@ CoW Protocol contracts are generally deployed to the same addresses on their res
 
 :::
 
-| **Contracts** | **Address / Chains** |
-|---|---|
-| [`EthFlow`](periphery/eth-flow)<br />Upgradeable: No ❎<br />[GitHub](https://github.com/cowprotocol/ethflowcontract/blob/main/src/CoWSwapEthFlow.sol) | Production: `0xbA3cB449bD2B4ADddBc894D8697F5170800EAdeC`<br />Staging: `0x04501b9b1D52e67f6862d157E00D13419D2D6E95`<br />- Ethereum mainnet ([production](https://etherscan.io/address/0xbA3cB449bD2B4ADddBc894D8697F5170800EAdeC), [staging](https://etherscan.io/address/0x04501b9b1D52e67f6862d157E00D13419D2D6E95))<br />- Gnosis chain ([production](https://gnosisscan.io/address/0xbA3cB449bD2B4ADddBc894D8697F5170800EAdeC), [staging](https://gnosisscan.io/address/0x04501b9b1D52e67f6862d157E00D13419D2D6E95))<br />- Arbitrum one ([production](https://arbiscan.io/address/0xbA3cB449bD2B4ADddBc894D8697F5170800EAdeC), [staging](https://arbiscan.io/address/0x04501b9b1D52e67f6862d157E00D13419D2D6E95))<br />- Base ([production](https://basescan.org/address/0xbA3cB449bD2B4ADddBc894D8697F5170800EAdeC), [staging](https://basescan.org/address/0x04501b9b1D52e67f6862d157E00D13419D2D6E95))<br />- Avalanche ([production](https://snowscan.xyz/address/0xbA3cB449bD2B4ADddBc894D8697F5170800EAdeC), [staging](https://snowscan.xyz/address/0x04501b9b1D52e67f6862d157E00D13419D2D6E95))<br />- Polygon ([production](https://polygonscan.com/address/0xbA3cB449bD2B4ADddBc894D8697F5170800EAdeC), [staging](https://polygonscan.com/address/0x04501b9b1D52e67f6862d157E00D13419D2D6E95))<br />- Sepolia ([production](https://sepolia.etherscan.io/address/0xbA3cB449bD2B4ADddBc894D8697F5170800EAdeC), [staging](https://sepolia.etherscan.io/address/0x04501b9b1D52e67f6862d157E00D13419D2D6E95)) |
-| [`HooksTrampoline`](periphery/hooks-trampoline)<br />Upgradeable: No ❎<br />[GitHub](https://github.com/cowprotocol/hooks-trampoline/blob/main/src/HooksTrampoline.sol) | `0x01DcB88678aedD0C4cC9552B20F4718550250574`<br />- [Ethereum mainnet](https://etherscan.io/address/0x01DcB88678aedD0C4cC9552B20F4718550250574)<br />- [Gnosis chain](https://gnosisscan.io/address/0x01DcB88678aedD0C4cC9552B20F4718550250574)<br/>- [Arbitrum one](https://arbiscan.io/address/0x01DcB88678aedD0C4cC9552B20F4718550250574)<br/>- [Base](https://basescan.org/address/0x01DcB88678aedD0C4cC9552B20F4718550250574)<br/>- [Avalanche](https://snowscan.xyz/address/0x01DcB88678aedD0C4cC9552B20F4718550250574) <br/>- [Polygon](https://polygonscan.com/address/0x01DcB88678aedD0C4cC9552B20F4718550250574) |
-| [`ComposableCoW`](periphery/composable-cow)<br />Upgradeable: No ❎<br />[GitHub](https://github.com/cowprotocol/composable-cow/blob/main/src/ComposableCoW.sol) | `0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74`<br />- [Ethereum mainnet](https://etherscan.io/address/0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74)<br />- [Gnosis chain](https://gnosisscan.io/address/0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74)<br/>- [Arbitrum one](https://arbiscan.io/address/0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74)<br/>- [Base](https://basescan.org/address/0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74)<br/>- [Avalanche](https://snowscan.xyz/address/0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74)<br/>- [Polygon](https://polygonscan.com/address/0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74)<br/>- [Sepolia](https://sepolia.etherscan.io/address/0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74) |
-| [`CoWUidGenerator`](periphery/cow-uid-generator)<br />Upgradeable: No ❎<br /> | `0xe84dcd8587287b997f51299430a396ad03aaec06` on the following networks:<br />- [Ethereum mainnet](https://etherscan.io/address/0xe84dcd8587287b997f51299430a396ad03aaec06)<br /><br />`0xCA51403B524dF7dA6f9D6BFc64895AD833b5d711` on the following networks:<br />- [Gnosis chain](https://gnosisscan.io/address/0xCA51403B524dF7dA6f9D6BFc64895AD833b5d711)<br/><br />`0x96ddDAC514d0799e34e3F642c5006852aD24CD68` on the following networks:<br />- [Base](https://basescan.org/address/0x96dddac514d0799e34e3f642c5006852ad24cd68) |
+### EthFlow
+
+**Documentation**: [`EthFlow`](periphery/eth-flow)  
+**Upgradeable**: No ❎  
+**GitHub**: [CoWSwapEthFlow.sol](https://github.com/cowprotocol/ethflowcontract/blob/main/src/CoWSwapEthFlow.sol)
+
+| Environment | Address | Networks |
+|-------------|---------|----------|
+| Production | `0xbA3cB449bD2B4ADddBc894D8697F5170800EAdeC` | [Mainnet](https://etherscan.io/address/0xbA3cB449bD2B4ADddBc894D8697F5170800EAdeC), [Gnosis chain](https://gnosisscan.io/address/0xbA3cB449bD2B4ADddBc894D8697F5170800EAdeC), [Arbitrum one](https://arbiscan.io/address/0xbA3cB449bD2B4ADddBc894D8697F5170800EAdeC), [Base](https://basescan.org/address/0xbA3cB449bD2B4ADddBc894D8697F5170800EAdeC), [Avalanche](https://snowscan.xyz/address/0xbA3cB449bD2B4ADddBc894D8697F5170800EAdeC), [Polygon](https://polygonscan.com/address/0xbA3cB449bD2B4ADddBc894D8697F5170800EAdeC), [Sepolia](https://sepolia.etherscan.io/address/0xbA3cB449bD2B4ADddBc894D8697F5170800EAdeC) |
+| Staging | `0x04501b9b1D52e67f6862d157E00D13419D2D6E95` | [Mainnet](https://etherscan.io/address/0x04501b9b1D52e67f6862d157E00D13419D2D6E95), [Gnosis chain](https://gnosisscan.io/address/0x04501b9b1D52e67f6862d157E00D13419D2D6E95), [Arbitrum one](https://arbiscan.io/address/0x04501b9b1D52e67f6862d157E00D13419D2D6E95), [Base](https://basescan.org/address/0x04501b9b1D52e67f6862d157E00D13419D2D6E95), [Avalanche](https://snowscan.xyz/address/0x04501b9b1D52e67f6862d157E00D13419D2D6E95), [Polygon](https://polygonscan.com/address/0x04501b9b1D52e67f6862d157E00D13419D2D6E95), [Sepolia](https://sepolia.etherscan.io/address/0x04501b9b1D52e67f6862d157E00D13419D2D6E95) |
+
+### HooksTrampoline
+
+**Documentation**: [`HooksTrampoline`](periphery/hooks-trampoline)  
+**Upgradeable**: No ❎  
+**GitHub**: [HooksTrampoline.sol](https://github.com/cowprotocol/hooks-trampoline/blob/main/src/HooksTrampoline.sol)
+
+**Address**: `0x01DcB88678aedD0C4cC9552B20F4718550250574`
+
+**Networks**: 
+[Mainnet](https://etherscan.io/address/0x01DcB88678aedD0C4cC9552B20F4718550250574), 
+[Gnosis chain](https://gnosisscan.io/address/0x01DcB88678aedD0C4cC9552B20F4718550250574), 
+[Arbitrum one](https://arbiscan.io/address/0x01DcB88678aedD0C4cC9552B20F4718550250574), 
+[Base](https://basescan.org/address/0x01DcB88678aedD0C4cC9552B20F4718550250574), 
+[Avalanche](https://snowscan.xyz/address/0x01DcB88678aedD0C4cC9552B20F4718550250574), 
+[Polygon](https://polygonscan.com/address/0x01DcB88678aedD0C4cC9552B20F4718550250574)
+
+### ComposableCoW
+
+**Documentation**: [`ComposableCoW`](periphery/composable-cow)  
+**Upgradeable**: No ❎  
+**GitHub**: [ComposableCoW.sol](https://github.com/cowprotocol/composable-cow/blob/main/src/ComposableCoW.sol)
+
+**Address**: `0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74`
+
+**Networks**: 
+[Mainnet](https://etherscan.io/address/0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74), 
+[Gnosis chain](https://gnosisscan.io/address/0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74), 
+[Arbitrum one](https://arbiscan.io/address/0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74), 
+[Base](https://basescan.org/address/0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74), 
+[Avalanche](https://snowscan.xyz/address/0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74), 
+[Polygon](https://polygonscan.com/address/0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74), 
+[Sepolia](https://sepolia.etherscan.io/address/0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74)
+
+### CoWUidGenerator
+
+**Documentation**: [`CoWUidGenerator`](periphery/cow-uid-generator)  
+**Upgradeable**: No ❎
+
+| Network | Address |
+|---------|---------|
+| [Mainnet](https://etherscan.io/address/0xe84dcd8587287b997f51299430a396ad03aaec06) | `0xe84dcd8587287b997f51299430a396ad03aaec06` |
+| [Gnosis chain](https://gnosisscan.io/address/0xCA51403B524dF7dA6f9D6BFc64895AD833b5d711) | `0xCA51403B524dF7dA6f9D6BFc64895AD833b5d711` |
+| [Base](https://basescan.org/address/0x96dddac514d0799e34e3f642c5006852ad24cd68) | `0x96ddDAC514d0799e34e3F642c5006852aD24CD68` |


### PR DESCRIPTION
# Description

This PR updates the trampoline contract to the latest version. 

## Additional networks
The contract was deployed also to many new networks like Binance, Optimism, Lens, Polygon and Avalanche

## Bonus
Adding all the periphery contracts in a single table with all the networks and relevant links made it a bit hard to mantain. 
Instead, I broke it down in sections, so it can be easier to read and maintain. 

Before:
<img width="810" height="893" alt="image" src="https://github.com/user-attachments/assets/ca628896-990c-4086-b815-44b9ca65e4f9" />

After:
<img width="1211" height="621" alt="image" src="https://github.com/user-attachments/assets/d64c13ee-173b-4e40-8895-ebc15e2f5e7a" />


## Out of scope 1
There's a discussion on hooks, with a nice introduction to them with the goal of clarifying all aspects of them and properly defining the rules. 

I believe that after properly defining that, we could move some of that content to https://docs.cow.fi/ because the hooks page and hook trampoline page are insufficient.

Out of scope also more improvements in the docs other than what I described in BONUS.

# Test review the page
Review  page: https://docs-git-update-trampoline-cowswap.vercel.app/cow-protocol/reference/contracts/periphery

For reference: https://docs.cow.fi/cow-protocol/reference/contracts/periphery 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the structure and readability of the periphery contracts documentation by organizing each contract into its own section with clear headings and details.
  * Updated the HooksTrampoline contract address and expanded its list of supported networks.
  * Enhanced tables for contract addresses and supported networks, providing clearer separation for production and staging environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->