### PR TITLE
Add hooks disclaimers

### DIFF
--- a/docs/cow-protocol/reference/contracts/periphery/README.mdx
+++ b/docs/cow-protocol/reference/contracts/periphery/README.mdx
@@ -2,6 +2,7 @@
 
 Peripheral contracts are those that are not necessary for CoW Protocol to function, but are used to enhance user experience.
 
+
 ## Deployments
 
 :::tip
@@ -27,7 +28,16 @@ CoW Protocol contracts are generally deployed to the same addresses on their res
 **Upgradeable**: No ❎  
 **GitHub**: [HooksTrampoline.sol](https://github.com/cowprotocol/hooks-trampoline/blob/main/src/HooksTrampoline.sol)
 
-**Address**: `0x60bf78233f48ec42ee3f101b9a05ec7878728006`
+**Address**: `0x60bf78233f48ec42ee3f101b9a05ec7878728006` 
+
+
+:::warning
+
+You should not assume that the HooksTrampoline contract address will remain fixed. Each solver may choose to use this implementation or another one, as long as it fulfills the hook intent.
+
+:::
+
+
 
 **Networks**: 
 [Mainnet](https://etherscan.io/address/0x60bf78233f48ec42ee3f101b9a05ec7878728006), 

--- a/docs/cow-protocol/reference/contracts/periphery/hooks_trampoline.md
+++ b/docs/cow-protocol/reference/contracts/periphery/hooks_trampoline.md
@@ -69,7 +69,7 @@ As a hook **developer**, you should:
 :::warning
 As a **solver**, you are responsible for:
 * Executing the hook. Whether via the HooksTrampoline contract or any alternative mechanism
-* Outcomes of that execution including any violation of CoW Protocol rules success (i.e. take buffers from settlement contract).
+* Outcomes of that execution, including any violation of CoW Protocol rules (e.g., taking buffers from the settlement contract) attributable to the solver's execution.
 :::
 
 ### Relying on the trampoline contract address

--- a/docs/cow-protocol/reference/contracts/periphery/hooks_trampoline.md
+++ b/docs/cow-protocol/reference/contracts/periphery/hooks_trampoline.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 
 # HooksTrampoline
 
-A helper contract used by solvers, to securely execute user's [hooks](/cow-protocol/reference/core/intents/hooks) with the settlement transaction.
+A helper contract that may be used by solvers to securely execute user's [hooks](/cow-protocol/reference/core/intents/hooks) within the settlement transaction.
 
 ## Architecture
 

--- a/docs/cow-protocol/reference/contracts/periphery/hooks_trampoline.md
+++ b/docs/cow-protocol/reference/contracts/periphery/hooks_trampoline.md
@@ -68,7 +68,7 @@ sequenceDiagram
 
 ### Relying on the trampoline contract address
 
-Most solvers will use the `HooksTrampoline` contract to execute hooks, as it offers strong security guarantees. However, the protocol does not mandate any specific implementation. In fact, solvers are not required to use an intermediary contract at all if they can ensure the security of their hooks by other means, they may do so and save gas.
+Solvers may use the `HooksTrampoline` contract to execute hooks, as it offers a pragmatic way to meet many of the security guarantees required of hook execution while still keeping the settlement submission logic relatively simple. However, the protocol does not mandate any specific implementation. In fact, solvers are not required to use an intermediary contract at all if they can ensure the security of their hooks by other means, they may do so and save gas.
 
 
 :::warning

--- a/docs/cow-protocol/reference/contracts/periphery/hooks_trampoline.md
+++ b/docs/cow-protocol/reference/contracts/periphery/hooks_trampoline.md
@@ -60,10 +60,16 @@ sequenceDiagram
 3. Enough gas is forwarded to the hooks to execute the logic
 
 :::warning
-
+As a hook **developer**, you should:
 * Beware of leaving any funds in the trampoline contract. These are accessible to anyone.
 * Do **NOT** grant any permissions to the trampoline contract. These are accessible to anyone.
 
+:::
+
+:::warning
+As a **solver**, you are responsible for:
+* Executing the hook. Whether via the HooksTrampoline contract or any alternative mechanism
+* Outcomes of that execution including any violation of CoW Protocol rules success (i.e. take buffers from settlement contract).
 :::
 
 ### Relying on the trampoline contract address


### PR DESCRIPTION
# Description

This PR adds some disclaimers and useful information related to the hooks trampoline contract.

I'm not good with texts, please, suggest any changes you see fit.


## Periphery
Adds a disclaimer (warning message below)

<img width="1232" height="431" alt="Screenshot at Aug 25 20-42-18" src="https://github.com/user-attachments/assets/1f75232d-6a7b-4f08-b822-14a6d7955f31" />


## Do not rely on msg.sender being the trampoline
Adds this section:

<img width="1095" height="376" alt="Screenshot at Aug 25 21-08-56" src="https://github.com/user-attachments/assets/ec2fde6c-636b-42ff-89df-336772e9694e" />

## Forwarded gas 
Added point 3 here:

<img width="1088" height="315" alt="image" src="https://github.com/user-attachments/assets/36a2ce1b-7033-429b-86ad-2b1b196158e6" />


## Changed the HooksTrampoline intro 

Before:
<img width="787" height="135" alt="image" src="https://github.com/user-attachments/assets/a5514282-3354-43bf-b812-6fa0b59b32b8" />

After
<img width="841" height="130" alt="image" src="https://github.com/user-attachments/assets/f6701731-2017-48af-a34e-a3bf8adf4d8d" />


## Test
- Periphery: https://docs-git-disclaimers-hooks-cowswap.vercel.app/cow-protocol/reference/contracts/periphery 
- Hooks Trampoline: https://docs-git-disclaimers-hooks-cowswap.vercel.app/cow-protocol/reference/contracts/periphery/hooks-trampoline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Clarified HooksTrampoline as a helper/reference for solvers and reframed architecture, guarantees, and narrative.
  - Added warnings for hook developers and solvers, including not assuming a fixed trampoline address or specific caller.
  - Noted that sufficient gas is forwarded to hooks and added a diagram step illustrating gas forwarding.
  - Minor formatting tweaks in the Deployments section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->