### PR TITLE
Fix typo

### DIFF
--- a/docs/cow-protocol/tutorials/arbitrate/orderbook.md
+++ b/docs/cow-protocol/tutorials/arbitrate/orderbook.md
@@ -49,7 +49,7 @@ sequenceDiagram
       Solver1-->>Order book: result
       Order book->>SolverN: quote?
       SolverN-->>Order book: result
-      Order book->>Order book: smualate & pick
+      Order book->>Order book: simulate & pick
     end
     Order book->>Database: insert order
     Order book-->>User: order UID


### PR DESCRIPTION
# Description

as the description states

# Changes

<!-- List of detailed changes (how the change is accomplished) -->

- [ ] smualate -> simulate

<!--
## Related Issues

Fixes #
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typo in a sequence diagram label, changing “smualate & pick” to “simulate & pick” for the Order Book step.
  - Improves clarity and readability of the tutorial content.
  - Ensures terminology accuracy in the depicted workflow.
  - No behavioral or functional changes to the product.
  - Users reading the tutorial will see the corrected label in the diagram.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->