### PR TITLE
Add linea to solver documentation

### DIFF
--- a/docs/cow-protocol/reference/core/auctions/competition_rules.md
+++ b/docs/cow-protocol/reference/core/auctions/competition_rules.md
@@ -121,6 +121,13 @@ At CoW DAO's discretion, systematic violation of these rules may lead to penaliz
   - **Base tokens**: [`WBNB`](https://bnbscan.com/address/0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c), [`BUSD`](https://bnbscan.com/address/0xe9e7cea3dedca5984780bafc599bd69add087d56), [`USDT`](https://bnbscan.com/address/0x55d398326f99059ff775485246999027b3197955), [`WETH`](https://bnbscan.com/address/0x2170ed0880ac9a755fd29b2688956bd959f933f8)
   </details>
 
+  <details>
+    <summary>Linea baseline protocols and tokens</summary>
+
+  - **Protocols**: Uniswap v3
+  - **Base tokens**: [`WETH`](https://lineascan.build/address/0xe5d7c2a44ffddf6b295a15c148167daaaf5cf34f), [`USDC`](https://lineascan.build/token/0x176211869ca2b568f2a7d4ee941e073a821ee1ff), [`USDT`](https://lineascan.build/token/0xa219439258ca9da29e9cc4ce5596924745e12b93)
+  </details>
+
 More details about how a certificate of an EBBO violation is computed, and what are the steps taken in case such a violation occurs can be found in [this](/cow-protocol/reference/core/auctions/ebbo-rules) section.
 
 - Inflation of the score ([CIP-11](https://snapshot.org/#/cow.eth/proposal/0x16d8c681d52b24f1ccd854084e07a99fce6a7af1e25fd21ddae6534b411df870)). Using tokens for the sole purpose of inflating the score of a solution or maximizing the reward is forbidden (e.g., by creating fake tokens, or wash-trading with real tokens).

--- a/docs/cow-protocol/reference/core/auctions/rewards.md
+++ b/docs/cow-protocol/reference/core/auctions/rewards.md
@@ -44,6 +44,7 @@ The payment is capped from above and below using the function $$\textrm{cap}(x) 
 - Polygon: $$c_l = 30 \;\textrm{POL}$$, $$c_u = 40 \;\textrm{POL}$$.
 - Lens: $$c_l = c_u = 10 \;\textrm{GHO}$$.
 - BNB: $$c_l = 0.04 \;\textrm{BNB}$$, $$c_u = 0.048 \;\textrm{BNB}$$.
+- Linea: $$c_l = 0.0015 \;\textrm{ETH}$$, $$c_u = 0.002 \;\textrm{ETH}$$.
 
 Solutions with scores that are non-positive will be ignored. If only one solver submits solutions, $$\textrm{referenceScore}_i$$ is, by definition, zero. Formally, this corresponds to always considering the empty solution which does not settle any trades and has a score equal to zero as part of the submitted solutions.
 
@@ -90,5 +91,6 @@ The current rewards for eligible quotes are as follows:
 - Polygon Chain: $$\min\{0.6 ~\textrm{POL}, 6 ~\textrm{COW}\}$$
 - Lens Chain: $$\min\{0.15 ~\textrm{GHO}, 6 ~\textrm{COW}\}$$
 - BNB Chain: $$\min\{0.001 ~\textrm{BNB}, 6 ~\textrm{COW}\}$$
+- Linea: $$\min\{0.00003 ~\textrm{ETH}, 6 ~\textrm{COW}\}$$.
 
 where, again, the conversion from native token to COW is done by using an up-to-date price (specifically, the average native token/COW Dune prices of the past 24h before the payout are used to determine these exchange rates).


### PR DESCRIPTION
# Description

This PR adds reward caps and base tokens and liquidity for Linea.

# Changes

Reward caps are set to similar levels as on Polygon. With the current price of POL ($0.1822) and ETH ($3623.32) this amounts to
- reward caps of of `c_l = 0.0015 ETH` (around $5.4, Polygon has 30 POL for around $5.5) and `c_u = 0.002 ETH` (around $7.2, Polygon has 40 POL for around $7.3), and
- quote caps of 0.00003 ETH (around $0.11, Polygon has around $0.11) or 6 COW.

Base liquidity is set to Uniswap v3 (according to the current driver config [here (access required)](https://github.com/cowprotocol/infrastructure/blob/92982a07ea2aa290fca5faa11f3bd667fe82d058/services/driver/liquidity.ts#L285C1-L294C9)) and base tokens are set to WETH, USDC, USDT (according to the current driver config [here (access required)](https://github.com/cowprotocol/infrastructure/blob/92982a07ea2aa290fca5faa11f3bd667fe82d058/services/driver/config/index.ts#L182C1-L187C3)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Linea network support to CoW Protocol auction documentation
  * Updated baseline protocol references with Linea's Uniswap v3 configuration and supported tokens
  * Added Linea rewards parameters to the rewards table with corresponding ETH and COW values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->