### PR TITLE
Simplify EBBO section

### DIFF
--- a/docs/cow-protocol/reference/core/auctions/ebbo_specifics.md
+++ b/docs/cow-protocol/reference/core/auctions/ebbo_specifics.md
@@ -23,7 +23,7 @@ The following steps are taken, in case an EBBO violation is detected, either by 
 
 3. Once the incident is communicated, the violating solver shall process the reimbursement within 72 hours of this notification.
    - If the violating solver complies, the case is closed.
-   - If the violating solver does not comply, the slashing procedure will be triggered (see section below)
+   - If the violating solver does not comply, the slashing procedure will be triggered (see section below).
 
 ## Escalation mechanism: Slashing of solver bond
 

--- a/docs/cow-protocol/reference/core/auctions/ebbo_specifics.md
+++ b/docs/cow-protocol/reference/core/auctions/ebbo_specifics.md
@@ -6,7 +6,6 @@ id: ebbo-rules
 
 In this section, we will elaborate on the details about what consistutes an EBBO violation, and what actions are taken by the DAO in case such a violation occurs. The content of this section is based on [CIP-52](https://snapshot.org/#/cow.eth/proposal/0x0f2f1fde68d85081a7d60f7ac99dafbdabdbf8c8cf55961f2609b3dff429a24a).
 
-
 ## Certificate of EBBO violation
 
 A certificate for an EBBO violation consists of a reference routing on a block (and log index) between the start of the auction and when the settlement happened onchain. A reference routing for a trade at a given block (and index) is an execution of that trade which only uses liquidity from base protocols and routes through base tokens (see the "Base protocols and tokens" section [here](/cow-protocol/reference/core/auctions/competition-rules) for the definition of base protocols and base tokens). The surplus received by users in this routing is used as reference surplus. The difference between the reference surplus and the surplus actually received by the user is the size of the EBBO violation. This amount needs to be reimbursed to a user.
@@ -15,16 +14,14 @@ A certificate for an EBBO violation can be challenged by the solver who is accus
 
 ## Reimbursement procedures
 
-The following steps are taken, in case an EBBO violation is detected, either by the core team’s monitoring infrastructure or a third party reach out (for example by the user themselves or by solvers). We clarify here that in order to avoid reports of very old trades that occurred at a time where the protocol was in earlier phases, violations will be inspected only if they are communicated within 3 months from the incident date.
+The following steps are taken, in case an EBBO violation is detected, either by the core team’s monitoring infrastructure or a third party reaching out (for example by the user themselves or by solvers). Violations will be inspected only if they are communicated within 3 months from the incident date.
 
-1. A violation is detected, within 3 months from the incident date.
+1. The core team calculates the value lost to users in a given settlement due to the EBBO violation, as described in the section above.
 
-2. The core team calculates the (minimum) value lost to users in a given settlement due to the EBBO violation, as described in the section above.
+2. The core team requests the involved solver team to reimburse the user directly, by informing them about the amount.
+  - The reimbursement is to be done in the surplus token and sent from an address directly linked to the responsible solver for clarity about who issued the refund. If the solver has no access to their submission account (in case this is managed by the core team), the reimbursement can be executed from the rewards address.
 
-3. The core team requests the involved solver team to reimburse the user directly, by informing them about the amount:
-  - The reimbursement is to be done in the surplus token and sent from a responsible solver’s submission / owned address for clarity about who issued the refund. If the solver has no access to their submission account (in case this is managed by the core team), then the core team should transfer any desired amount from the submission account to a solver-related address (i.e. their rewards account), if such a request is made from the solver.
-
-4. Once the incident is communicated, the violating Solver shall process the reimbursement within 72 hours of this notification.
+3. Once the incident is communicated, the violating solver shall process the reimbursement within 72 hours of this notification.
   - If the violating solver complies, the case is closed.
   - If the violating solver does not comply, the slashing procedure will be triggered (see section below)
 
@@ -36,8 +33,6 @@ With a successful passing of the CIP:
 - The solver bond in question is slashed in the amount of refund calculated and triggers repayment to the user;
 - If the vote does not pass, the solver is re-instated.
 
-A solver with a slashed bond can resume activity if the solver bond is replenished. If the solver is part of the CoW DAO bond, CoW DAO may decide in the Solver Bond Slashing CIP to replenish the bond from its own funds. This approach would prevent other bond participants from being negatively impacted.
+A solver with a slashed bond can resume activity if the solver bond is replenished. If the solver is part of the CoW DAO bond, CoW DAO may decide in the CIP to replenish the bond from its own funds. This approach would prevent other bond participants from being negatively impacted.
 
 The CIP vote is then binding for all parties.
-
-We also clarify that if a solver would like to stop operating and obtain the (remainder) of their bond back - which requires a CIP - they can ask to have this transaction included in the same CIP.

--- a/docs/cow-protocol/reference/core/auctions/ebbo_specifics.md
+++ b/docs/cow-protocol/reference/core/auctions/ebbo_specifics.md
@@ -19,11 +19,11 @@ The following steps are taken, in case an EBBO violation is detected, either by 
 1. The core team calculates the value lost to users in a given settlement due to the EBBO violation, as described in the section above.
 
 2. The core team requests the involved solver team to reimburse the user directly, by informing them about the amount.
-  - The reimbursement is to be done in the surplus token and sent from an address directly linked to the responsible solver for clarity about who issued the refund. If the solver has no access to their submission account (in case this is managed by the core team), the reimbursement can be executed from the rewards address.
+   - The reimbursement is to be done in the surplus token and sent from an address directly linked to the responsible solver for clarity about who issued the refund. If the solver has no access to their submission account (in case this is managed by the core team), the reimbursement can be executed from the rewards address.
 
 3. Once the incident is communicated, the violating solver shall process the reimbursement within 72 hours of this notification.
-  - If the violating solver complies, the case is closed.
-  - If the violating solver does not comply, the slashing procedure will be triggered (see section below)
+   - If the violating solver complies, the case is closed.
+   - If the violating solver does not comply, the slashing procedure will be triggered (see section below)
 
 ## Escalation mechanism: Slashing of solver bond
 


### PR DESCRIPTION
This PR streamlines the EBBO section in the documentation a bit.

The docs and the corresponding CIP included some wording which was not particularly clear to me. I removed some sentences and remarks and also fied some formatiing and typo.

Most of the old formulations were part of the CIP and can be found in the link already included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Tightened EBBO violation intro and clarified certificate semantics
  * Reordered and clarified reimbursement steps (value-loss first, request second, notification third)
  * Clarified reimbursement source allowing execution from rewards address if needed; specified 72-hour processing and outcomes
  * Simplified escalation to a CIP-based slashing flow (removed deny-list/forum steps and note about reclaiming bond)
  * Minor wording and consistency improvements

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->