### PR TITLE
feat: add Troubleshooting for widget

### DIFF
--- a/docs/cow-protocol/tutorials/widget/widget.md
+++ b/docs/cow-protocol/tutorials/widget/widget.md
@@ -597,4 +597,4 @@ This banner will be hidden:
 
 ### White background of the iframe
 
-1. If you use ` <meta name="color-scheme">` in your HTML document, it might affect the widget iframe background color. Try to remove the meta tag in that case. 
+1. If you use `<meta name="color-scheme">` in your HTML document, it might affect the widget iframe background color. Try to remove the meta tag in that case. 

--- a/docs/cow-protocol/tutorials/widget/widget.md
+++ b/docs/cow-protocol/tutorials/widget/widget.md
@@ -592,3 +592,9 @@ createCowSwapWidget(container, { params })
 This banner will be hidden:
 
 ![Hidden banner](/img/tutorials/widget-hidden-banner.png)
+
+## Troubleshooting
+
+### White background of the iframe
+
+1. If you use ` <meta name="color-scheme">` in your HTML document, it might affect the widget iframe background color. Try to remove the meta tag in that case. 


### PR DESCRIPTION
# Description

Solution of white iframe background color from one of the integrators.
More details: https://gist.github.com/jdanyow/9916d77f09089f8c6f7993438f8c292a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Troubleshooting section addressing widget display issues where an iframe may show a white background; explains how a page-level color-scheme meta tag can affect the widget and advises removing or adjusting that meta tag to restore expected appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->