### PR TITLE
Update token.md - Include COW in BNB address

### DIFF
--- a/docs/governance/token.md
+++ b/docs/governance/token.md
@@ -19,7 +19,7 @@ At the core of CoW Protocol lies the COW token, which serves as a governance tok
 | Polygon      | [`0x2f4efd3aa42e15a1ec6114547151b63ee5d39958`](https://polygonscan.com/token/0x2f4efd3aa42e15a1ec6114547151b63ee5d39958) [^bridgedTokens] |
 | Avalanche    | N/A                                                                                                                                       |
 | Lens         | N/A                                                                                                                                       |
-| BNB          | [0x5bfdaa3f7c28b9994b56135403bf1acea02595b0](https://bscscan.com/token/0x5bfdaa3f7c28b9994b56135403bf1acea02595b0)                        |
+| BNB          | [`0x5bfdaa3f7c28b9994b56135403bf1acea02595b0`](https://bscscan.com/token/0x5bfdaa3f7c28b9994b56135403bf1acea02595b0)                      |
 | Linea        | N/A                                                                                                                                       |
 | Plasma       | N/A                                                                                                                                       |
 

--- a/docs/governance/token.md
+++ b/docs/governance/token.md
@@ -19,13 +19,16 @@ At the core of CoW Protocol lies the COW token, which serves as a governance tok
 | Polygon      | [`0x2f4efd3aa42e15a1ec6114547151b63ee5d39958`](https://polygonscan.com/token/0x2f4efd3aa42e15a1ec6114547151b63ee5d39958) [^bridgedTokens] |
 | Avalanche    | N/A                                                                                                                                       |
 | Lens         | N/A                                                                                                                                       |
-| BNB          | [`0x5bfdaa3f7c28b9994b56135403bf1acea02595b0`](https://bscscan.com/token/0x5bfdaa3f7c28b9994b56135403bf1acea02595b0)                      |
+| BNB          | [`0x5bfdaa3f7c28b9994b56135403bf1acea02595b0`](https://bscscan.com/token/0x5bfdaa3f7c28b9994b56135403bf1acea02595b0) [^stargateBridge]    |
 | Linea        | N/A                                                                                                                                       |
 | Plasma       | N/A                                                                                                                                       |
 
 [^bridgedTokens]:
     These contracts were not developed nor deployed by CoW DAO, however, they are the bridged versions of the canonical token from Ethereum, using the official bridges.
     [Omni bridge](https://gnosisscan.io/address/0xf6A78083ca3e2a662D6dd1703c939c8aCE2e268d#code) for Gnosis Chain, [Arbitrum One bridge](https://arbiscan.io/address/0x09e9222e96e7b4ae2a407b98d48e330053351eee#code) for Arbitrum one, [Superbridge](https://basescan.org/tx/0xf76a915b7db279a4e559dbc382462e23cb63615f3d3a87ddf36bd96cedf4ca56) for Base, and [Polygon Bridge](https://portal.polygon.technology/bridge) for Polygon.
+
+[^stargateBridge]:
+    These contracts were not developed nor deployed by CoW DAO, however, they are the bridged versions deployed using [Stargate](https://stargate.finance/).
 
 #### `vCOW` - Vesting token
 

--- a/docs/governance/token.md
+++ b/docs/governance/token.md
@@ -19,7 +19,7 @@ At the core of CoW Protocol lies the COW token, which serves as a governance tok
 | Polygon      | [`0x2f4efd3aa42e15a1ec6114547151b63ee5d39958`](https://polygonscan.com/token/0x2f4efd3aa42e15a1ec6114547151b63ee5d39958) [^bridgedTokens] |
 | Avalanche    | N/A                                                                                                                                       |
 | Lens         | N/A                                                                                                                                       |
-| BNB          | N/A                                                                                                                                       |
+| BNB          | [0x5bfdaa3f7c28b9994b56135403bf1acea02595b0](https://bscscan.com/token/0x5bfdaa3f7c28b9994b56135403bf1acea02595b0)                        |
 | Linea        | N/A                                                                                                                                       |
 | Plasma       | N/A                                                                                                                                       |
 


### PR DESCRIPTION
Add address to BNB version of COW.
Did not include footnote as the bridged token does use stargate and not a native bridge.

Thread with context and validation of token address: https://cowservices.slack.com/archives/C06G1E3AU77/p1758625335858369

# Description

<!--- Describe your changes to provide context for reviewers, including why it is needed -->

# Changes

<!-- List of detailed changes (how the change is accomplished) -->

- [ ] ...
- [ ] ...

<!--
## Related Issues

Fixes #
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the COW token entry for BNB to include the correct token contract address and a link to the blockchain explorer.
  * Added a new footnote explaining Stargate-bridged contracts; existing bridged-token footnote remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->