### PR TITLE
Add note to onboarding document about request size

### DIFF
--- a/docs/cow-protocol/tutorials/solvers/onboard.md
+++ b/docs/cow-protocol/tutorials/solvers/onboard.md
@@ -47,6 +47,8 @@ The exposed endpoint provided must be of the following format: {base_url}/\${env
 envName values: shadow, staging, prod
 supported networks: arbitrum-one, avalanche, base, bnb, lens, linea, mainnet, polygon, xdai (gnosis) and more are coming out!
 
+> **_NOTE_** The `/solve` response sent to your solver is quite large. If you are using Nginx then the default request size will be too small and prevent you from receiving any auctions.
+
 ### Driver configuration for your solver
 There are various configurations for your solver in the driver to help you optimize your solver: 
 

--- a/docs/cow-protocol/tutorials/solvers/onboard.md
+++ b/docs/cow-protocol/tutorials/solvers/onboard.md
@@ -47,7 +47,9 @@ The exposed endpoint provided must be of the following format: {base_url}/\${env
 envName values: shadow, staging, prod
 supported networks: arbitrum-one, avalanche, base, bnb, lens, linea, mainnet, polygon, xdai (gnosis) and more are coming out!
 
-> **_NOTE_** The `/solve` response sent to your solver is quite large. If you are using Nginx then the default request size will be too small and prevent you from receiving any auctions.
+:::note
+The `/solve` response sent to your solver is quite large. If you are using Nginx then the default request size will be too small and prevent you from receiving any auctions.
+:::
 
 ### Driver configuration for your solver
 There are various configurations for your solver in the driver to help you optimize your solver: 


### PR DESCRIPTION
# Description
This PR adds a note to the onboarding document to solvers to increase the default request size for Nginx. We notice many solvers running into this issue and not realizing this until we look into the logs. By adding this to the documentation we will hopefully make it easier for solvers to debug or avoid this in the future.

# Changes
- [ ] Add note to the solver's onboarding document that the auction size is larger than the Nginx default

<!--
## Related Issues

Fixes #
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added warnings in the solver onboarding guide about large /solve responses and default Nginx request size limits that can block reception of auctions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->