### PR TITLE
Affiliate: Remove INK from unsupported chains

### DIFF
--- a/docs/cow-protocol/affiliate-program/faq.md
+++ b/docs/cow-protocol/affiliate-program/faq.md
@@ -106,7 +106,7 @@ No. Swaps that are economically non-meaningful, below minimum protocol-fee thres
 
 #### Is the Affiliate Program available on all chains?
 
-The program applies to all supported CoW Swap chains, except Ink and Sepolia.
+The program applies to all supported CoW Swap chains, except Sepolia.
 
 ### Payouts & Tracking
 


### PR DESCRIPTION
INK is a supported chain for Affiliate program volumes. 
See https://nomevlabs.slack.com/archives/C07BMTK4F19/p1775472435797329

**To test:** 
1. Open https://docs-git-ink-supported-cowswap.vercel.app/cow-protocol/affiliate-program/faq#is-the-affiliate-program-available-on-all-chains

**ER**: INK chain is not mentioned there. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Affiliate Program FAQ to clarify supported network availability. The program now applies to all supported CoW Swap chains except Sepolia (previously excluded Ink and Sepolia).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->