### PR TITLE
Mention protocol fee token explicitly

### DIFF
--- a/docs/governance/fees/fees.md
+++ b/docs/governance/fees/fees.md
@@ -51,6 +51,8 @@ The purpose of this page is to let users know which fee models are active at any
 
 **Quote improvement** is defined as the difference between the executed price and the quoted price for an order, so long as the value is positive (if the value is negative, no fee is taken)
 
+All protocol fees are charged in the surplus token, i.e. in the buy token for sell orders and the sell token for buy orders.
+
 :::
 
 ### Partner fees


### PR DESCRIPTION
# Description

Add clarifying sentence on the currency protocol fees are charged in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified protocol fee charging mechanism, specifying that fees are charged in the surplus token, with directional definitions for buy and sell orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->