### PR TITLE
fix: correct duplicate parameter in signature verification table

### DIFF
--- a/docs/cow-protocol/reference/contracts/periphery/composable_cow.md
+++ b/docs/cow-protocol/reference/contracts/periphery/composable_cow.md
@@ -92,7 +92,7 @@ function isValidSafeSignature(
 | `domainSeparator` | See [`EIP-712`](https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator) |
 | `typeHash` | Not used |
 | `encodeData` | ABI-encoded [`GPv2Order.Data`](../core/settlement.md#gpv2orderdata-struct) (per [`EIP-712`](https://eips.ethereum.org/EIPS/eip-712#definition-of-encodedata)) to be settled |
-| `encodeData` | ABI-encoded [`GPv2Order.Data`](../core/settlement.md#gpv2orderdata-struct) to be settled |
+| `payload` | ABI-encoded [`PayloadStruct`](#payloadstruct) containing the Merkle proof, conditional order parameters, and off-chain input |
 
 In order to delegate signature verification to `ComposableCoW`, the delegating contract may either:
 


### PR DESCRIPTION
## Summary
- Fixed duplicate `encodeData` entry in the signature verification parameter table
- Replaced the second `encodeData` row with the missing `payload` parameter and added its description linking to the `PayloadStruct` section

Fixes #430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for the `payload` parameter, specifying it contains ABI-encoded Merkle proof and conditional order data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->