### PR TITLE
Remove a note that cross-chain swaps are not available for SC wallets

### DIFF
--- a/docs/cow-protocol/tutorials/cow-swap/swap-and-bridge.mdx
+++ b/docs/cow-protocol/tutorials/cow-swap/swap-and-bridge.mdx
@@ -30,11 +30,6 @@ This guide will walk you through the process step-by-step, from setting up your 
 
 <img src={SwapFormImg.src} style={{ maxWidth: 500 }} alt="Cross-chain swaps" />
 
-:::note
-
-Currently, the Cross-chain swaps functionality is limited to swap orders and is not available for smart contract wallets. These features will be available in the future.
-
-:::
 
 ---
 


### PR DESCRIPTION
Removed a note about limitations of cross-chain swaps functionality on https://docs.cow.fi/cow-protocol/tutorials/cow-swap/swap-and-bridge


<img width="1054" height="709" alt="image" src="https://github.com/user-attachments/assets/84edc272-f46f-4134-b8df-1b037f328535" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

To test: open https://docs-git-remove-note-cowswap.vercel.app/cow-protocol/tutorials/cow-swap/swap-and-bridge

## Summary by CodeRabbit

* **Documentation**
  * Removed a limitation note regarding cross-chain swaps from the swap and bridge tutorial documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cowprotocol/docs/pull/626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->