### PR TITLE
docs: add `Solver7702Delegate` docs

### DIFF
--- a/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
+++ b/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
@@ -55,7 +55,7 @@ We also want to reduce the overall workload of a solver engine, since it's usual
 That process includes:
 
 - fetching additional metadata (e.g. token decimals)
-- discarding orders that can definitely not be settled (e.g. user is missing balances)
+- discarding orders that cannot be settled (e.g. user is missing balances)
 - very basic prioritization of remaining orders (e.g. orders below or close to the market price are most likely to settle)
 
 ### Fetching liquidity

--- a/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
+++ b/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
@@ -53,9 +53,10 @@ The auctions sent to the driver by the autopilot only contain the bare minimum o
 But usually a solver engine requires more information than that so the driver pre-processes the auction before forwarding it to the solver engine.
 We also want to reduce the overall workload of a solver engine, since it's usually expensive to match an order (in terms of time, RPC requests, API calls, etc.).
 That process includes:
-* fetching additional metadata (e.g. token decimals)
-* discarding orders that can definitely not be settled (e.g. user is missing balances)
-* very basic prioritization of remaining orders (e.g. orders below or close to the market price are most likely to settle)
+
+- fetching additional metadata (e.g. token decimals)
+- discarding orders that can definitely not be settled (e.g. user is missing balances)
+- very basic prioritization of remaining orders (e.g. orders below or close to the market price are most likely to settle)
 
 ### Fetching liquidity
 
@@ -92,10 +93,11 @@ The driver can be configured to use different submission strategies which it dyn
 If the settlement does not expose any MEV (e.g. it executes all trades without AMMs) it's safe and most efficient to directly submit to the public mempool.
 However, if a settlement exposes MEV the driver would submit to an MEV-protected RPC like [MEVBlocker](https://mevblocker.io).
 
+Solvers that need parallel settlement submission can use [Solver7702Delegate](../../solvers/solver-7702-delegate.md). It keeps the existing solver EOA as the settlement caller while auxiliary EOAs provide additional nonce lanes if the main solver EOA has pending transactions.
+
 ### Flash Loans
 
 The user is able to create a flash loan order's hint by attaching to the `appData` the specified metadata. The autopilot reads the order and cuts it into a [fair combinatorial batch auction](../../../concepts/introduction/fair-combinatorial-auction). Then the driver fetches the `appData` by calling the orderbook with `GET /v1/app_data/<app_data_hash>` for every order and caches them in memory. The driver should include the flash loan information into the batch auction's order before sending it to the solver(s).
-
 
 ```mermaid
 sequenceDiagram

--- a/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
+++ b/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
@@ -93,7 +93,7 @@ The driver can be configured to use different submission strategies which it dyn
 If the settlement does not expose any MEV (e.g. it executes all trades without AMMs) it's safe and most efficient to directly submit to the public mempool.
 However, if a settlement exposes MEV the driver would submit to an MEV-protected RPC like [MEVBlocker](https://mevblocker.io).
 
-Solvers that need parallel settlement submission can use [Solver7702Delegate](../../solvers/solver-7702-delegate.md). It keeps the existing solver EOA as the settlement caller while auxiliary EOAs provide additional nonce lanes if the main solver EOA has pending transactions.
+Solvers that expect real settlement volume should set up [Solver7702Delegate](../../solvers/solver-7702-delegate.md) early. It keeps the existing solver EOA as the settlement caller while auxiliary EOAs provide additional nonce lanes when the solver EOA has pending transactions.
 
 ### Flash Loans
 

--- a/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
+++ b/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
@@ -93,7 +93,7 @@ The driver can be configured to use different submission strategies which it dyn
 If the settlement does not expose any MEV (e.g. it executes all trades without AMMs) it's safe and most efficient to directly submit to the public mempool.
 However, if a settlement exposes MEV the driver would submit to an MEV-protected RPC like [MEVBlocker](https://mevblocker.io).
 
-Production solvers using the reference driver should configure [Solver7702Delegate](../../solvers/solver-7702-delegate.md) during initial driver setup. A single pending solver EOA transaction can delay later settlements; auxiliary EOAs provide additional nonce lanes while `GPv2Settlement` still sees the solver EOA as the settlement caller.
+Production solvers using the reference driver should configure [Solver7702Delegate](../../solvers/solver-7702-delegate.md) during initial driver setup. A single pending solver EOA transaction can delay later settlements; auxiliary accounts provide additional nonce lanes while `GPv2Settlement` still sees the solver EOA as the settlement caller.
 
 ### Flash Loans
 

--- a/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
+++ b/docs/cow-protocol/tutorials/arbitrate/solver/driver.md
@@ -93,7 +93,7 @@ The driver can be configured to use different submission strategies which it dyn
 If the settlement does not expose any MEV (e.g. it executes all trades without AMMs) it's safe and most efficient to directly submit to the public mempool.
 However, if a settlement exposes MEV the driver would submit to an MEV-protected RPC like [MEVBlocker](https://mevblocker.io).
 
-Solvers that expect real settlement volume should set up [Solver7702Delegate](../../solvers/solver-7702-delegate.md) early. It keeps the existing solver EOA as the settlement caller while auxiliary EOAs provide additional nonce lanes when the solver EOA has pending transactions.
+Production solvers using the reference driver should configure [Solver7702Delegate](../../solvers/solver-7702-delegate.md) during initial driver setup. A single pending solver EOA transaction can delay later settlements; auxiliary EOAs provide additional nonce lanes while `GPv2Settlement` still sees the solver EOA as the settlement caller.
 
 ### Flash Loans
 

--- a/docs/cow-protocol/tutorials/solvers/onboard.md
+++ b/docs/cow-protocol/tutorials/solvers/onboard.md
@@ -48,7 +48,7 @@ The first step to joining the solver competition is to set up a solver. We have 
 
 API specification: <https://github.com/cowprotocol/services/blob/main/crates/solvers/openapi.yml>
 
-Solvers that need parallel settlement submission can use [Solver7702Delegate](./solver-7702-delegate.md) to keep their existing solver EOA while adding extra submission nonce lanes.
+Solvers that expect real settlement volume should set up [Solver7702Delegate](./solver-7702-delegate.md) early. It keeps the existing solver EOA while adding extra submission nonce lanes for parallel settlement submission.
 
 ## 3. Joining the shadow (test) competition
 

--- a/docs/cow-protocol/tutorials/solvers/onboard.md
+++ b/docs/cow-protocol/tutorials/solvers/onboard.md
@@ -48,6 +48,8 @@ The first step to joining the solver competition is to set up a solver. We have 
 
 API specification: <https://github.com/cowprotocol/services/blob/main/crates/solvers/openapi.yml>
 
+Solvers that need parallel settlement submission can use [Solver7702Delegate](./solver-7702-delegate.md) to keep their existing solver EOA while adding extra submission nonce lanes.
+
 ## 3. Joining the shadow (test) competition
 
 Once you have a solver running locally you can join the shadow competition to start testing your solver using CoW Protocol's order flow.

--- a/docs/cow-protocol/tutorials/solvers/onboard.md
+++ b/docs/cow-protocol/tutorials/solvers/onboard.md
@@ -48,8 +48,6 @@ The first step to joining the solver competition is to set up a solver. We have 
 
 API specification: <https://github.com/cowprotocol/services/blob/main/crates/solvers/openapi.yml>
 
-Solvers that expect real settlement volume should set up [Solver7702Delegate](./solver-7702-delegate.md) early. It keeps the existing solver EOA while adding extra submission nonce lanes for parallel settlement submission.
-
 ## 3. Joining the shadow (test) competition
 
 Once you have a solver running locally you can join the shadow competition to start testing your solver using CoW Protocol's order flow.

--- a/docs/cow-protocol/tutorials/solvers/solver-7702-delegate.md
+++ b/docs/cow-protocol/tutorials/solvers/solver-7702-delegate.md
@@ -4,157 +4,81 @@ sidebar_position: 11
 
 # Using Solver7702Delegate for parallel settlement submission
 
-`Solver7702Delegate` is an ERC-7702 delegation target for CoW Protocol solvers. It lets a solver keep using its existing allowlisted solver EOA, while extra submission EOAs send settlement transactions through that solver EOA.
+`Solver7702Delegate` lets a solver keep its existing allowlisted solver EOA while using auxiliary EOAs as extra submission nonce lanes.
 
-The main use case is parallel settlement submission. A single EOA has one nonce lane. If settlement `B` uses nonce `101`, it has to wait for the nonce of settlement `A` with nonce `100` to be mined. With `Solver7702Delegate`, each auxiliary EOA has its own nonce lane, but the settlement contract still sees the solver EOA as `msg.sender`.
+This is strongly recommended for solvers that expect real volume. With one EOA, a pending settlement can block every later settlement behind the same nonce lane. With `Solver7702Delegate`, auxiliary EOAs can submit in parallel, while `GPv2Settlement` still sees the solver EOA as `msg.sender`.
 
-## Why use it?
+## Reference driver setup
 
-Without ERC-7702, a solver that wants parallel submission would need one of these options:
-
-- allowlist several solver EOAs;
-- migrate to a smart contract solver account;
-- keep using one EOA and accept one nonce lane.
-
-`Solver7702Delegate` keeps the current solver identity. The solver EOA delegates execution to the delegate contract, and a fixed set of auxiliary EOAs can call through it.
-
-```text
-auxiliary EOA 1 -> solver EOA running Solver7702Delegate -> GPv2Settlement
-auxiliary EOA 2 -> solver EOA running Solver7702Delegate -> GPv2Settlement
-auxiliary EOA 3 -> solver EOA running Solver7702Delegate -> GPv2Settlement
-```
-
-Inside the delegate:
-
-```text
-msg.sender = auxiliary EOA
-address(this) = solver EOA
-```
-
-Inside `GPv2Settlement`:
-
-```text
-msg.sender = solver EOA
-```
-
-This keeps settlement authorization tied to the solver EOA.
-
-## Call shape
-
-Normal settlement submission:
-
-```text
-from = solver EOA
-to   = GPv2Settlement
-data = GPv2Settlement.settle(...)
-```
-
-ERC-7702 settlement submission:
-
-```text
-from = auxiliary EOA
-to   = solver EOA
-data = bytes20(target) || targetCalldata
-```
-
-For a settlement:
-
-```text
-target         = GPv2Settlement
-targetCalldata = GPv2Settlement.settle(...)
-```
-
-The calldata format is packed on purpose:
-
-```solidity
-abi.encodePacked(bytes20(target), targetCalldata)
-```
-
-Do not use this format:
-
-```solidity
-abi.encode(target, targetCalldata)
-```
-
-The first 20 bytes are parsed as the target address. The remaining bytes are forwarded as calldata. Return data and revert data are bubbled back as-is.
-
-## Contract model
-
-`Solver7702Delegate` has no normal public methods. Its interface is the constructor and `fallback()`:
-
-```solidity
-constructor(address[5] memory approvedCallers);
-fallback() external payable;
-```
-
-A fixed number of approved callers is set in the constructor. They are embedded into the deployed bytecode, not stored in contract storage. This keeps the hot path small and avoids mutable admin logic.
-
-If calldata is shorter than 20 bytes, the fallback accepts ETH and returns. Otherwise, it checks that `msg.sender` is one of the approved callers, parses the target address from the first 20 bytes, and calls the target from the solver EOA context.
-
-Only `CALL` is supported. `DELEGATECALL` is not supported, because the delegate already runs in the solver EOA context through ERC-7702.
-
-There are no events. This keeps gas lower for the submission path.
-
-## Setup
-
-The exact setup depends on whether you use the reference driver or your own driver.
-
-At a high level:
-
-1. Choose a number of auxiliary EOAs up to the limit defined in `Solver7702Delegate`.
-2. Deploy `Solver7702Delegate` with those auxiliary EOAs as approved callers.
-3. Have the solver EOA sign an ERC-7702 authorization pointing to the delegate.
-4. Submit a transaction that includes that authorization.
-5. Verify that the solver EOA now delegates to the expected delegate.
-6. Configure the driver to use the auxiliary EOAs for delegated submission.
-
-If you use the reference driver, configure extra submission accounts for the solver. The driver treats these as EIP-7702 submission accounts and sets up the delegate and delegation during startup when the accounts are available as signers.
+If you use the reference driver, add `submission-accounts` to the solver entry in your driver config. This is the main setup path for most solvers.
 
 ```toml
 [[solver]]
 name = "my-solver"
 endpoint = "https://solver.example"
 account = "<solver-private-key-or-signer-config>"
-max-solutions-to-propose = 2
+max-solutions-to-propose = 6 # solver EOA + N auxiliary EOAs
 submission-accounts = [
   "<auxiliary-private-key-or-signer-config-1>",
   "<auxiliary-private-key-or-signer-config-2>",
-  ...
+  "<auxiliary-private-key-or-signer-config-3>",
+  "<auxiliary-private-key-or-signer-config-4>",
+  "<auxiliary-private-key-or-signer-config-5>"
 ]
 ```
 
-The solver `account` must be able to sign the ERC-7702 authorization. Submission accounts must also be signer-backed, not address-only config.
+The solver `account` must be able to sign the ERC-7702 authorization. Each `submission-accounts` entry must also be signer with a private key, not just an address.
 
-When `submission-accounts` is set, the reference driver:
+Fund each auxiliary EOA with native token for gas, as they will be used to submit transactions separately from the solver EOA.
 
-- requires every submission account to be a signer;
-- supports up to the number of submission accounts defined in `Solver7702Delegate`;
-- pads unused approved caller slots with the zero address;
-- deploys the delegate through [Arachnid's deterministic CREATE2 deployer](https://github.com/Arachnid/deterministic-deployment-proxy) with zero salt;
-- reuses the same delegate deployment if the expected code is already present (using CREATE2 and the same constructor arguments);
+When `submission-accounts` is configured, the reference driver:
 
-If `max-solutions-to-propose` is greater than `1`, `submission-accounts` must be configured. The driver refuses to start otherwise, because proposing multiple solutions needs parallel submission lanes.
+- sets up `Solver7702Delegate` during startup when the required signers are available;
+- uses the auxiliary accounts as extra settlement nonce lanes, when solver EOA is busy;
+- reuses the expected delegate deployment when the same code is already present;
+- refuses to start with `max-solutions-to-propose > 1` unless submission accounts are configured.
 
-If you run a custom driver, it must:
+## What changes when submitting
 
-- deploy the delegate with the expected caller set;
-- create the ERC-7702 authorization for the solver EOA;
-- submit the authorization transaction;
-- sign the authorization for the next nonce if the solver EOA also sends the authorization transaction;
-- route delegated settlements with `to = solver EOA`;
-- encode delegated calldata as `bytes20(target) || targetCalldata`;
-- simulate the exact transaction shape before sending it.
+Direct submission should still be used when the solver EOA is free. Delegated submission is useful when the solver EOA already has a pending transaction and another settlement should be submitted without waiting for that nonce.
 
-The reference driver sends the delegation setup as an inert zero-value transaction from the solver EOA to the zero address with the ERC-7702 authorization attached. It does not combine delegation setup with delegate deployment, because a reverted transaction can still leave the ERC-7702 authorization applied.
+```mermaid
+flowchart LR
+    SolverEOA{"Solver EOA"}
+    DirectTx["tx.from = solver EOA<br/>tx.to = GPv2Settlement<br/>tx.data = settle(...)"]
+    AuxEOAs{"Auxiliary EOAs<br/>0...N"}
+    DelegatedTx["tx.from = auxiliary EOA<br/>tx.to = solver EOA<br/>tx.data = bytes20(target)<br/>+ targetCalldata"]
+    DelegatedSolver["Solver EOA running<br/>Solver7702Delegate"]
+    TargetCall["target = GPv2Settlement<br/>targetCalldata = settle(...)"]
+    Settlement["GPv2Settlement"]
 
-With Foundry, this means using `cast wallet sign-auth --self-broadcast` when the solver EOA submits its own authorization transaction. Do not use `--self-broadcast` when a different funded EOA submits that transaction.
+    SolverEOA --> DirectTx --> Settlement
+    AuxEOAs --> DelegatedTx --> DelegatedSolver --> TargetCall --> Settlement
+
+    classDef eoa fill:#fff3bf,stroke:#b08900,color:#1f2937
+    classDef tx fill:#f3f0ff,stroke:#7048e8,color:#1f2937
+    classDef contract fill:#1864ab,stroke:#0b3558,stroke-width:3px,color:#ffffff,font-weight:bold
+    class SolverEOA,AuxEOAs eoa
+    class DirectTx,DelegatedTx,TargetCall tx
+    class DelegatedSolver,Settlement contract
+```
+
+Inside the delegate, `msg.sender` is the auxiliary EOA and `address(this)` is the solver EOA. Inside `GPv2Settlement`, `msg.sender` is still the solver EOA.
+
+The calldata format is packed on purpose. Use `abi.encodePacked(bytes20(target), targetCalldata)`. Do not use `abi.encode(target, targetCalldata)`.
 
 ## Verification
 
 Before using delegated submission, verify both pieces:
 
 1. The solver EOA delegates to the expected delegate.
-2. The delegate bytecode matches the expected caller set.
+2. The delegate bytecode matches the expected approved caller set.
+
+Check the solver EOA code:
+
+```shell
+cast code <solver_eoa> --rpc-url <rpc_url>
+```
 
 For ERC-7702, delegated account code has this shape:
 
@@ -162,134 +86,78 @@ For ERC-7702, delegated account code has this shape:
 0xef0100 || delegateAddress
 ```
 
-So the solver EOA code should be 23 bytes:
+The delegate bytecode check matters because approved callers are immutable constructor values. Do not only check that the delegate address has code.
 
-```text
-0xef0100<20-byte delegate address>
+## Manual cast commands
+
+Most solvers should use the reference driver setup above. Use these commands only if you are setting up delegation manually and/or building a custom driver.
+
+**To authorize a delegate when the solver EOA sends its own authorization transaction, sign with `--self-broadcast`**:
+
+```shell
+cast wallet sign-auth <delegate_address> \
+  --private-key <solver_private_key> \
+  --rpc-url <rpc_url> \
+  --chain <chain_id> \
+  --self-broadcast
+
+cast send 0x0000000000000000000000000000000000000000 \
+  --auth <signed_authorization> \
+  --private-key <solver_private_key> \
+  --rpc-url <rpc_url> \
+  --chain <chain_id>
 ```
 
-The delegate bytecode must also be checked. Because approved callers are immutable constructor values, each solver's deployed runtime bytecode can be different. Do not only check that the delegate address has code. Compute the expected runtime bytecode from:
+**If a different funded account sends either transaction, do not use `--self-broadcast` when signing.** The solver EOA signs the authorization, but the funded account pays gas and submits the transaction:
 
-- the official `Solver7702Delegate` artifact;
-- the compiler settings;
-- the approved caller addresses.
+```shell
+cast wallet sign-auth <delegate_or_zero_address> \
+  --private-key <solver_private_key> \
+  --rpc-url <rpc_url> \
+  --chain <chain_id>
 
-Then compare that expected runtime bytecode, or its hash, with `eth_getCode(delegateAddress)`.
-
-## How the driver should submit
-
-Prefer direct submission when the solver EOA is idle:
-
-```text
-from = solver EOA
-to   = GPv2Settlement
-data = settle(...)
+cast send 0x0000000000000000000000000000000000000000 \
+  --auth <signed_authorization> \
+  --private-key <transaction_sender_private_key> \
+  --rpc-url <rpc_url> \
+  --chain <chain_id>
 ```
 
-Use delegated submission when the solver EOA already has a pending transaction and parallel submission is useful:
+To revoke delegation, sign an authorization to the zero address:
 
-```text
-from = auxiliary EOA
-to   = solver EOA
-data = bytes20(GPv2Settlement) || settle(...)
+```shell
+cast wallet sign-auth 0x0000000000000000000000000000000000000000 \
+  --private-key <solver_private_key> \
+  --rpc-url <rpc_url> \
+  --chain <chain_id> \
+  --self-broadcast
+
+cast send 0x0000000000000000000000000000000000000000 \
+  --auth <signed_authorization> \
+  --private-key <solver_private_key> \
+  --rpc-url <rpc_url> \
+  --chain <chain_id>
 ```
 
-Each auxiliary EOA has its own nonce lane. Do not send more than one transaction from the same auxiliary EOA unless you intentionally want nonce ordering for that account.
+## Custom driver requirements
 
-The driver should simulate the same transaction shape it will submit. For delegated submission, that means simulating with:
+If you do not use the reference driver, your driver must:
 
-- `from = auxiliary EOA`;
-- `to = solver EOA`;
-- `data = bytes20(target) || targetCalldata`;
-- the solver EOA already delegated to the expected `Solver7702Delegate`.
+- deploy `Solver7702Delegate` for the approved auxiliary caller set;
+- have the solver EOA delegate to the deployed `Solver7702Delegate`;
+- route delegated settlement transactions with `from = auxiliary EOA` and `to = solver EOA` (if solver EOA is busy);
+- encode delegated calldata as `bytes20(target) || targetCalldata`.
 
-## Funding
+## Capabilities and limits
 
-Auxiliary EOAs pay gas. The delegate does not fund them.
+- Version 1 supports up to five immutable approved caller slots.
+- Approved auxiliary EOAs are trusted hot keys. They can trigger arbitrary calls as the solver EOA.
+- Changing authorized auxiliary accounts requires redeploying the delegate and re-delegating the solver EOA.
+- The delegate can call arbitrary targets. The driver should normally use `GPv2Settlement` for settlement submissions.
+- Use this only on chains and infrastructure that support ERC-7702 transaction authorization handling.
 
-If an auxiliary EOA is underfunded:
+Keep solver EOA funds and approvals minimal, do not share auxiliary EOAs across solvers, and rotate callers immediately if an auxiliary key is compromised.
 
-- skip it;
-- alert the operator;
-- use another idle funded account;
-- fall back to direct submission if that is safe;
-- otherwise wait.
+## More details
 
-## Replacing callers
-
-Approved callers cannot be changed on an existing delegate. To replace any auxiliary EOA:
-
-1. Deploy a new `Solver7702Delegate` with the new caller set.
-2. Have the solver EOA sign a new ERC-7702 authorization to the new delegate.
-3. Submit the replacement authorization transaction.
-4. Verify the solver EOA code is `0xef0100 || newDelegate`.
-5. Verify the new delegate runtime bytecode matches the new caller set.
-6. Update driver config and monitoring.
-7. Treat the old delegate as deprecated.
-
-The old delegate remains on-chain, but it has no power unless the solver EOA delegates to it.
-
-## Revoking delegation
-
-To clear ERC-7702 delegation:
-
-1. Have the solver EOA sign an ERC-7702 authorization to the zero address.
-2. Submit a transaction with that authorization.
-3. Verify that the solver EOA no longer has delegated code.
-4. Disable delegated submission in the driver.
-5. Fall back to direct solver EOA submission.
-
-Revocation is useful when auxiliary submission is no longer needed, or when the caller set cannot be safely replaced immediately.
-
-## Compromised auxiliary key response
-
-Treat a compromised auxiliary EOA as severe. An approved auxiliary EOA can trigger arbitrary calls from the solver EOA context until it is removed.
-
-Recommended response:
-
-1. Disable ERC-7702 submission for that solver.
-2. Consider disabling the solver while you assess the risk.
-3. Deploy a new `Solver7702Delegate` without the compromised caller.
-4. Have the solver EOA authorize the new delegate.
-5. Verify delegation and delegate bytecode.
-6. Move funds and revoke approvals from the solver EOA if needed.
-7. Mark the old delegate/config as deprecated in monitoring.
-
-If replacement cannot be done quickly, clear the solver EOA delegation and use direct submission only.
-
-## Warnings
-
-Approved auxiliary EOAs are trusted hot keys. They can cause arbitrary calls from the solver EOA context. That includes token transfers, approvals, protocol interactions, and ETH transfers if the solver EOA holds funds.
-
-Use these safeguards:
-
-- do not share auxiliary EOAs across solvers;
-- keep solver EOA funds and approvals minimal;
-- monitor auxiliary keys and delegated calls;
-- rotate callers immediately if a key is compromised;
-- only enable this on chains and infrastructure that support ERC-7702 transaction authorization handling;
-- fall back to direct solver EOA submission when ERC-7702 is not supported.
-
-`Solver7702Delegate` does not implement ERC-721 or ERC-1155 receiver functions. It is meant for settlement submission, not for receiving NFTs.
-
-## FAQ
-
-### How many auxiliary EOAs are supported?
-
-Version 1 supports up to five immutable approved caller slots.
-
-### Can the delegate call only `GPv2Settlement`?
-
-No. It supports arbitrary targets. The driver should normally use `GPv2Settlement` as the target for settlement submissions.
-
-### Can an auxiliary EOA drain funds?
-
-The contract does not prevent that. Approved auxiliary EOAs are trusted execution keys. Keep funds and approvals on the solver EOA as small as possible.
-
-### What happens when all auxiliary EOAs are busy?
-
-The driver should wait or queue until one lane is idle. It should not reuse the same auxiliary EOA unless nonce ordering is intended.
-
-### Should direct submission still be used?
-
-Yes. Direct submission is cheaper and simpler when the solver EOA is idle. Delegated submission is useful when parallel settlement submission adds value.
+For exact manual deployment, authorization, revocation, bytecode verification, and operational procedures, use the [`Solver7702Delegate` README](https://github.com/cowprotocol/solver-7702-delegate).

--- a/docs/cow-protocol/tutorials/solvers/solver-7702-delegate.md
+++ b/docs/cow-protocol/tutorials/solvers/solver-7702-delegate.md
@@ -11,15 +11,15 @@ keywords:
 
 # Parallel Settlement Submission
 
-[`Solver7702Delegate`](https://github.com/cowprotocol/solver-7702-delegate/blob/main/src/Solver7702Delegate.sol) lets a solver keep its existing allowlisted EOA and use auxiliary EOAs as additional nonce lanes for settlement submission.
+[`Solver7702Delegate`](https://github.com/cowprotocol/solver-7702-delegate/blob/main/src/Solver7702Delegate.sol) lets a solver keep its existing allowlisted EOA and use auxiliary accounts as additional nonce lanes for settlement submission. For more context on the basic flow, see the [`Solver7702Delegate` README](https://github.com/cowprotocol/solver-7702-delegate#readme).
 
-If a solver may submit more than one settlement at a time, it can set this up early. Ethereum executes transactions from the same EOA in nonce order, so one pending transaction can block subsequent settlement transactions. Auxiliary EOAs can submit in parallel, while `GPv2Settlement` still sees the solver EOA as `msg.sender`.
+If a solver may submit more than one settlement at a time, it can set this up early. Ethereum executes transactions from the same EOA in nonce order, so one pending transaction can block subsequent settlement transactions. Auxiliary accounts can submit in parallel, while `GPv2Settlement` still sees the solver EOA as `msg.sender`.
 
 :::warning
 
-Treat auxiliary EOAs as operationally sensitive accounts. Any approved auxiliary EOA can submit settlements through the solver EOA while the delegation is active. Keep their keys in the same security setup as the solver EOA, monitor their native-token balances, and make sure the team responsible for the solver EOA is also responsible for these accounts.
+Treat auxiliary accounts as operationally sensitive accounts. Any approved auxiliary account can submit settlements through the solver EOA while the delegation is active. Keep their keys in the same security setup as the solver EOA, monitor their native-token balances, and make sure the team responsible for the solver EOA is also responsible for these accounts.
 
-If an auxiliary key is compromised, rotate the delegation by configuring a new approved caller set and re-delegating from the solver EOA.
+If an auxiliary account key is compromised, rotate the delegation by configuring a new approved caller set and re-delegating from the solver EOA.
 
 :::
 
@@ -32,54 +32,63 @@ If you use the reference driver, add `submission-accounts` to the solver entry i
 name = "my-solver"
 endpoint = "https://solver.example"
 account = "<solver-private-key-or-signer-config>"
-max-solutions-to-propose = 6 # solver EOA + 5 auxiliary EOAs
+max-solutions-to-propose = 6 # solver EOA + 5 auxiliary accounts
 submission-accounts = [
-  "<auxiliary-private-key-or-signer-config-1>",
-  "<auxiliary-private-key-or-signer-config-2>",
-  "<auxiliary-private-key-or-signer-config-3>",
-  "<auxiliary-private-key-or-signer-config-4>",
-  "<auxiliary-private-key-or-signer-config-5>"
+  "<auxiliary-account-private-key-or-signer-config-1>",
+  "<auxiliary-account-private-key-or-signer-config-2>",
+  "<auxiliary-account-private-key-or-signer-config-3>",
+  "<auxiliary-account-private-key-or-signer-config-4>",
+  "<auxiliary-account-private-key-or-signer-config-5>"
 ]
 ```
 
 The solver `account` must be able to sign the ERC-7702 authorization. Each `submission-accounts` entry must also include signing credentials, not only an address.
 
-Fund each auxiliary EOA with the chain's native token so it can pay gas.
+Fund each auxiliary account with the chain's native token so it can pay gas.
 
 At startup, the reference driver deploys `Solver7702Delegate` at the expected CREATE2 address, or reuses the existing deployment at that address. When the solver EOA is busy, it uses the auxiliary accounts to submit settlements through separate nonce lanes.
 
-The delegate is immutable. Approved auxiliary EOAs are hardcoded into the deployed bytecode, so the caller set cannot be changed after deployment. To change it, deploy a new delegate and re-delegate the solver EOA.
+The delegate is immutable. Approved auxiliary accounts are hardcoded into the deployed bytecode, so the caller set cannot be changed after deployment. To change it, deploy a new delegate and re-delegate the solver EOA.
+
+## Custom driver setup
+
+If you run a custom driver, use the [`Solver7702Delegate` README](https://github.com/cowprotocol/solver-7702-delegate#usage) for the deployment and authorization flow. You can also use the reference driver implementation as a guide for how to:
+
+- deploy or reuse the delegate;
+- authorize the solver EOA to delegate to it;
+- route delegated settlement transactions through configured auxiliary accounts;
+- simulate the same transaction shape that will be submitted.
 
 ## What changes when submitting
 
-When the solver EOA is free, it submits directly to `GPv2Settlement`. If it already has a pending transaction, an auxiliary EOA can submit to the solver EOA instead. The solver EOA runs `Solver7702Delegate`, which forwards the call to `GPv2Settlement`.
+When the solver EOA is free, it submits directly to `GPv2Settlement`. If it already has a pending transaction, an auxiliary account can submit to the solver EOA instead. The solver EOA runs `Solver7702Delegate`, which forwards the call to `GPv2Settlement`.
 
 ```mermaid
 flowchart LR
     SolverEOA{"Solver EOA"}
     DirectTx["tx.data = settle(...)"]
-    Aux1{"Auxiliary EOA 1"}
-    Aux2{"Auxiliary EOA 2"}
-    Aux3{"Auxiliary EOA 3"}
-    Aux4{"Auxiliary EOA 4"}
-    Aux5{"Auxiliary EOA 5"}
+    Auxiliary1{"Auxiliary account 1"}
+    Auxiliary2{"Auxiliary account 2"}
+    Auxiliary3{"Auxiliary account 3"}
+    Auxiliary4{"Auxiliary account 4"}
+    Auxiliary5{"Auxiliary account 5"}
     DelegatedTx["tx.data = bytes20(target)<br/>|| targetCalldata"]
     DelegatedSolver["Solver EOA<br/>delegated to Solver7702Delegate"]
     TargetCall["target = GPv2Settlement<br/>targetCalldata = settle(...)"]
     Settlement["GPv2Settlement"]
 
     SolverEOA --> DirectTx --> Settlement
-    Aux1 --> DelegatedTx
-    Aux2 --> DelegatedTx
-    Aux3 --> DelegatedTx
-    Aux4 --> DelegatedTx
-    Aux5 --> DelegatedTx
+    Auxiliary1 --> DelegatedTx
+    Auxiliary2 --> DelegatedTx
+    Auxiliary3 --> DelegatedTx
+    Auxiliary4 --> DelegatedTx
+    Auxiliary5 --> DelegatedTx
     DelegatedTx --> DelegatedSolver --> TargetCall --> Settlement
 
-    classDef eoa fill:#fff3bf,stroke:#b08900,color:#1f2937
+    classDef account fill:#fff3bf,stroke:#b08900,color:#1f2937
     classDef tx fill:#f3f0ff,stroke:#7048e8,color:#1f2937
     classDef contract fill:#1864ab,stroke:#0b3558,stroke-width:3px,color:#ffffff,font-weight:bold
-    class SolverEOA,Aux1,Aux2,Aux3,Aux4,Aux5 eoa
+    class SolverEOA,Auxiliary1,Auxiliary2,Auxiliary3,Auxiliary4,Auxiliary5 account
     class DirectTx,DelegatedTx,TargetCall tx
     class DelegatedSolver,Settlement contract
 ```

--- a/docs/cow-protocol/tutorials/solvers/solver-7702-delegate.md
+++ b/docs/cow-protocol/tutorials/solvers/solver-7702-delegate.md
@@ -1,0 +1,292 @@
+---
+sidebar_position: 11
+---
+
+# Using Solver7702Delegate for parallel settlement submission
+
+`Solver7702Delegate` is an ERC-7702 delegation target for CoW Protocol solvers. It lets a solver keep using its existing allowlisted solver EOA, while extra submission EOAs send settlement transactions through that solver EOA.
+
+The main use case is parallel settlement submission. A single EOA has one nonce lane. If settlement `B` uses nonce `101`, it has to wait for the nonce of settlement `A` with nonce `100` to be mined. With `Solver7702Delegate`, each auxiliary EOA has its own nonce lane, but the settlement contract still sees the solver EOA as `msg.sender`.
+
+## Why use it?
+
+Without ERC-7702, a solver that wants parallel submission would need one of these options:
+
+- allowlist several solver EOAs;
+- migrate to a smart contract solver account;
+- keep using one EOA and accept one nonce lane.
+
+`Solver7702Delegate` keeps the current solver identity. The solver EOA delegates execution to the delegate contract, and a fixed set of auxiliary EOAs can call through it.
+
+```text
+auxiliary EOA 1 -> solver EOA running Solver7702Delegate -> GPv2Settlement
+auxiliary EOA 2 -> solver EOA running Solver7702Delegate -> GPv2Settlement
+auxiliary EOA 3 -> solver EOA running Solver7702Delegate -> GPv2Settlement
+```
+
+Inside the delegate:
+
+```text
+msg.sender = auxiliary EOA
+address(this) = solver EOA
+```
+
+Inside `GPv2Settlement`:
+
+```text
+msg.sender = solver EOA
+```
+
+This keeps settlement authorization tied to the solver EOA.
+
+## Call shape
+
+Normal settlement submission:
+
+```text
+from = solver EOA
+to   = GPv2Settlement
+data = GPv2Settlement.settle(...)
+```
+
+ERC-7702 settlement submission:
+
+```text
+from = auxiliary EOA
+to   = solver EOA
+data = bytes20(target) || targetCalldata
+```
+
+For a settlement:
+
+```text
+target         = GPv2Settlement
+targetCalldata = GPv2Settlement.settle(...)
+```
+
+The calldata format is packed on purpose:
+
+```solidity
+abi.encodePacked(bytes20(target), targetCalldata)
+```
+
+Do not use this format:
+
+```solidity
+abi.encode(target, targetCalldata)
+```
+
+The first 20 bytes are parsed as the target address. The remaining bytes are forwarded as calldata. Return data and revert data are bubbled back as-is.
+
+## Contract model
+
+`Solver7702Delegate` has no normal public methods. Its interface is the constructor and `fallback()`:
+
+```solidity
+constructor(address[5] memory approvedCallers);
+fallback() external payable;
+```
+
+A fixed number of approved callers is set in the constructor. They are embedded into the deployed bytecode, not stored in contract storage. This keeps the hot path small and avoids mutable admin logic.
+
+If calldata is shorter than 20 bytes, the fallback accepts ETH and returns. Otherwise, it checks that `msg.sender` is one of the approved callers, parses the target address from the first 20 bytes, and calls the target from the solver EOA context.
+
+Only `CALL` is supported. `DELEGATECALL` is not supported, because the delegate already runs in the solver EOA context through ERC-7702.
+
+There are no events. This keeps gas lower for the submission path.
+
+## Setup
+
+The exact setup depends on whether you use the reference driver or your own driver.
+
+At a high level:
+
+1. Choose a number of auxiliary EOAs up to the limit defined in `Solver7702Delegate`.
+2. Deploy `Solver7702Delegate` with those auxiliary EOAs as approved callers.
+3. Have the solver EOA sign an ERC-7702 authorization pointing to the delegate.
+4. Submit a transaction that includes that authorization.
+5. Verify that the solver EOA now delegates to the expected delegate.
+6. Configure the driver to use the auxiliary EOAs for delegated submission.
+
+If you use the reference driver, configure extra submission accounts for the solver. The driver treats these as EIP-7702 submission accounts and sets up the delegate and delegation during startup when the accounts are available as signers.
+
+```toml
+[[solver]]
+name = "my-solver"
+endpoint = "https://solver.example"
+account = "<solver-private-key-or-signer-config>"
+max-solutions-to-propose = 2
+submission-accounts = [
+  "<auxiliary-private-key-or-signer-config-1>",
+  "<auxiliary-private-key-or-signer-config-2>",
+  ...
+]
+```
+
+The solver `account` must be able to sign the ERC-7702 authorization. Submission accounts must also be signer-backed, not address-only config.
+
+When `submission-accounts` is set, the reference driver:
+
+- requires every submission account to be a signer;
+- supports up to the number of submission accounts defined in `Solver7702Delegate`;
+- pads unused approved caller slots with the zero address;
+- deploys the delegate through [Arachnid's deterministic CREATE2 deployer](https://github.com/Arachnid/deterministic-deployment-proxy) with zero salt;
+- reuses the same delegate deployment if the expected code is already present (using CREATE2 and the same constructor arguments);
+
+If `max-solutions-to-propose` is greater than `1`, `submission-accounts` must be configured. The driver refuses to start otherwise, because proposing multiple solutions needs parallel submission lanes.
+
+If you run a custom driver, it must:
+
+- deploy the delegate with the expected caller set;
+- create the ERC-7702 authorization for the solver EOA;
+- submit the authorization transaction;
+- route delegated settlements with `to = solver EOA`;
+- encode delegated calldata as `bytes20(target) || targetCalldata`;
+- simulate the exact transaction shape before sending it.
+
+The reference driver sends the delegation setup as an inert zero-value transaction from the solver EOA to the zero address with the ERC-7702 authorization attached. It does not combine delegation setup with delegate deployment, because a reverted transaction can still leave the ERC-7702 authorization applied.
+
+## Verification
+
+Before using delegated submission, verify both pieces:
+
+1. The solver EOA delegates to the expected delegate.
+2. The delegate bytecode matches the expected caller set.
+
+For ERC-7702, delegated account code has this shape:
+
+```text
+0xef0100 || delegateAddress
+```
+
+So the solver EOA code should be 23 bytes:
+
+```text
+0xef0100<20-byte delegate address>
+```
+
+The delegate bytecode must also be checked. Because approved callers are immutable constructor values, each solver's deployed runtime bytecode can be different. Do not only check that the delegate address has code. Compute the expected runtime bytecode from:
+
+- the official `Solver7702Delegate` artifact;
+- the compiler settings;
+- the approved caller addresses.
+
+Then compare that expected runtime bytecode, or its hash, with `eth_getCode(delegateAddress)`.
+
+## How the driver should submit
+
+Prefer direct submission when the solver EOA is idle:
+
+```text
+from = solver EOA
+to   = GPv2Settlement
+data = settle(...)
+```
+
+Use delegated submission when the solver EOA already has a pending transaction and parallel submission is useful:
+
+```text
+from = auxiliary EOA
+to   = solver EOA
+data = bytes20(GPv2Settlement) || settle(...)
+```
+
+Each auxiliary EOA has its own nonce lane. Do not send more than one transaction from the same auxiliary EOA unless you intentionally want nonce ordering for that account.
+
+The driver should simulate the same transaction shape it will submit. For delegated submission, that means simulating with:
+
+- `from = auxiliary EOA`;
+- `to = solver EOA`;
+- `data = bytes20(target) || targetCalldata`;
+- the solver EOA already delegated to the expected `Solver7702Delegate`.
+
+## Funding
+
+Auxiliary EOAs pay gas. The delegate does not fund them.
+
+If an auxiliary EOA is underfunded:
+
+- skip it;
+- alert the operator;
+- use another idle funded account;
+- fall back to direct submission if that is safe;
+- otherwise wait.
+
+## Replacing callers
+
+Approved callers cannot be changed on an existing delegate. To replace any auxiliary EOA:
+
+1. Deploy a new `Solver7702Delegate` with the new caller set.
+2. Have the solver EOA sign a new ERC-7702 authorization to the new delegate.
+3. Submit the replacement authorization transaction.
+4. Verify the solver EOA code is `0xef0100 || newDelegate`.
+5. Verify the new delegate runtime bytecode matches the new caller set.
+6. Update driver config and monitoring.
+7. Treat the old delegate as deprecated.
+
+The old delegate remains on-chain, but it has no power unless the solver EOA delegates to it.
+
+## Revoking delegation
+
+To clear ERC-7702 delegation:
+
+1. Have the solver EOA sign an ERC-7702 authorization to the zero address.
+2. Submit a transaction with that authorization.
+3. Verify that the solver EOA no longer has delegated code.
+4. Disable delegated submission in the driver.
+5. Fall back to direct solver EOA submission.
+
+Revocation is useful when auxiliary submission is no longer needed, or when the caller set cannot be safely replaced immediately.
+
+## Compromised auxiliary key response
+
+Treat a compromised auxiliary EOA as severe. An approved auxiliary EOA can trigger arbitrary calls from the solver EOA context until it is removed.
+
+Recommended response:
+
+1. Disable ERC-7702 submission for that solver.
+2. Consider disabling the solver while you assess the risk.
+3. Deploy a new `Solver7702Delegate` without the compromised caller.
+4. Have the solver EOA authorize the new delegate.
+5. Verify delegation and delegate bytecode.
+6. Move funds and revoke approvals from the solver EOA if needed.
+7. Mark the old delegate/config as deprecated in monitoring.
+
+If replacement cannot be done quickly, clear the solver EOA delegation and use direct submission only.
+
+## Warnings
+
+Approved auxiliary EOAs are trusted hot keys. They can cause arbitrary calls from the solver EOA context. That includes token transfers, approvals, protocol interactions, and ETH transfers if the solver EOA holds funds.
+
+Use these safeguards:
+
+- do not share auxiliary EOAs across solvers;
+- keep solver EOA funds and approvals minimal;
+- monitor auxiliary keys and delegated calls;
+- rotate callers immediately if a key is compromised;
+- only enable this on chains and infrastructure that support ERC-7702 transaction authorization handling;
+- fall back to direct solver EOA submission when ERC-7702 is not supported.
+
+`Solver7702Delegate` does not implement ERC-721 or ERC-1155 receiver functions. It is meant for settlement submission, not for receiving NFTs.
+
+## FAQ
+
+### How many auxiliary EOAs are supported?
+
+Version 1 supports up to five immutable approved caller slots.
+
+### Can the delegate call only `GPv2Settlement`?
+
+No. It supports arbitrary targets. The driver should normally use `GPv2Settlement` as the target for settlement submissions.
+
+### Can an auxiliary EOA drain funds?
+
+The contract does not prevent that. Approved auxiliary EOAs are trusted execution keys. Keep funds and approvals on the solver EOA as small as possible.
+
+### What happens when all auxiliary EOAs are busy?
+
+The driver should wait or queue until one lane is idle. It should not reuse the same auxiliary EOA unless nonce ordering is intended.
+
+### Should direct submission still be used?
+
+Yes. Direct submission is cheaper and simpler when the solver EOA is idle. Delegated submission is useful when parallel settlement submission adds value.

--- a/docs/cow-protocol/tutorials/solvers/solver-7702-delegate.md
+++ b/docs/cow-protocol/tutorials/solvers/solver-7702-delegate.md
@@ -15,6 +15,14 @@ keywords:
 
 Solvers expecting production volume should set this up early. With one EOA, a pending transaction can block every settlement behind it. Auxiliary EOAs can submit in parallel, while `GPv2Settlement` still sees the solver EOA as `msg.sender`.
 
+:::warning
+
+Treat auxiliary EOAs as operationally sensitive accounts. Any approved auxiliary EOA can submit settlements through the solver EOA while the delegation is active. Keep their keys in the same security setup as the solver EOA, monitor their native-token balances, and make sure the team responsible for the solver EOA is also responsible for these accounts.
+
+If an auxiliary key is compromised, rotate the delegation by configuring a new approved caller set and re-delegating from the solver EOA.
+
+:::
+
 ## Reference driver setup
 
 If you use the reference driver, add `submission-accounts` to the solver entry in your driver config. This is all most solvers need to configure.
@@ -37,14 +45,6 @@ submission-accounts = [
 The solver `account` must be able to sign the ERC-7702 authorization. Each `submission-accounts` entry must also include signing credentials, not only an address.
 
 Fund each auxiliary EOA with the chain's native token so it can pay gas.
-
-:::warning
-
-Treat auxiliary EOAs as operationally sensitive accounts. Any approved auxiliary EOA can submit settlements through the solver EOA while the delegation is active. Keep their keys in the same security setup as the solver EOA, monitor their native-token balances, and make sure the team responsible for the solver EOA is also responsible for these accounts.
-
-If an auxiliary key is compromised, rotate the delegation by configuring a new approved caller set and re-delegating from the solver EOA.
-
-:::
 
 At startup, the reference driver deploys `Solver7702Delegate` at the expected CREATE2 address, or reuses the existing deployment at that address. When the solver EOA is busy, it uses the auxiliary accounts to submit settlements through separate nonce lanes.
 

--- a/docs/cow-protocol/tutorials/solvers/solver-7702-delegate.md
+++ b/docs/cow-protocol/tutorials/solvers/solver-7702-delegate.md
@@ -140,11 +140,14 @@ If you run a custom driver, it must:
 - deploy the delegate with the expected caller set;
 - create the ERC-7702 authorization for the solver EOA;
 - submit the authorization transaction;
+- sign the authorization for the next nonce if the solver EOA also sends the authorization transaction;
 - route delegated settlements with `to = solver EOA`;
 - encode delegated calldata as `bytes20(target) || targetCalldata`;
 - simulate the exact transaction shape before sending it.
 
 The reference driver sends the delegation setup as an inert zero-value transaction from the solver EOA to the zero address with the ERC-7702 authorization attached. It does not combine delegation setup with delegate deployment, because a reverted transaction can still leave the ERC-7702 authorization applied.
+
+With Foundry, this means using `cast wallet sign-auth --self-broadcast` when the solver EOA submits its own authorization transaction. Do not use `--self-broadcast` when a different funded EOA submits that transaction.
 
 ## Verification
 

--- a/docs/cow-protocol/tutorials/solvers/solver-7702-delegate.md
+++ b/docs/cow-protocol/tutorials/solvers/solver-7702-delegate.md
@@ -94,7 +94,7 @@ First, check that the solver EOA points to the expected delegate:
 cast code <solver_eoa> --rpc-url <rpc_url>
 ```
 
-For ERC-7702, the code has this form:
+Make sure, the returned code follows [ERC-7702](https://eips.ethereum.org/EIPS/eip-7702) standard. The code should be:
 
 ```text
 0xef0100 || delegate_address

--- a/docs/cow-protocol/tutorials/solvers/solver-7702-delegate.md
+++ b/docs/cow-protocol/tutorials/solvers/solver-7702-delegate.md
@@ -38,6 +38,14 @@ The solver `account` must be able to sign the ERC-7702 authorization. Each `subm
 
 Fund each auxiliary EOA with the chain's native token so it can pay gas.
 
+:::warning
+
+Treat auxiliary EOAs as operationally sensitive accounts. Any approved auxiliary EOA can submit settlements through the solver EOA while the delegation is active. Keep their keys in the same security setup as the solver EOA, monitor their native-token balances, and make sure the team responsible for the solver EOA is also responsible for these accounts.
+
+If an auxiliary key is compromised, rotate the delegation by configuring a new approved caller set and re-delegating from the solver EOA.
+
+:::
+
 At startup, the reference driver deploys `Solver7702Delegate` at the expected CREATE2 address, or reuses the existing deployment at that address. When the solver EOA is busy, it uses the auxiliary accounts to submit settlements through separate nonce lanes.
 
 ## What changes when submitting

--- a/docs/cow-protocol/tutorials/solvers/solver-7702-delegate.md
+++ b/docs/cow-protocol/tutorials/solvers/solver-7702-delegate.md
@@ -1,23 +1,30 @@
 ---
 sidebar_position: 11
+description: Configure Solver7702Delegate and ERC-7702 auxiliary accounts for parallel settlement submission.
+keywords:
+  - Solver7702Delegate
+  - solver 7702 delegate
+  - ERC-7702
+  - EIP-7702
+  - parallel settlement submission
 ---
 
-# Using Solver7702Delegate for parallel settlement submission
+# Parallel Settlement Submission
 
-`Solver7702Delegate` lets a solver keep its existing allowlisted solver EOA while using auxiliary EOAs as extra submission nonce lanes.
+`Solver7702Delegate` lets a solver keep its existing allowlisted EOA and use auxiliary EOAs as additional nonce lanes for settlement submission.
 
-This is strongly recommended for solvers that expect real volume. With one EOA, a pending settlement can block every later settlement behind the same nonce lane. With `Solver7702Delegate`, auxiliary EOAs can submit in parallel, while `GPv2Settlement` still sees the solver EOA as `msg.sender`.
+Solvers expecting production volume should set this up early. With one EOA, a pending transaction can block every settlement behind it. Auxiliary EOAs can submit in parallel, while `GPv2Settlement` still sees the solver EOA as `msg.sender`.
 
 ## Reference driver setup
 
-If you use the reference driver, add `submission-accounts` to the solver entry in your driver config. This is the main setup path for most solvers.
+If you use the reference driver, add `submission-accounts` to the solver entry in your driver config. This is all most solvers need to configure.
 
 ```toml
 [[solver]]
 name = "my-solver"
 endpoint = "https://solver.example"
 account = "<solver-private-key-or-signer-config>"
-max-solutions-to-propose = 6 # solver EOA + N auxiliary EOAs
+max-solutions-to-propose = 6 # solver EOA + 5 auxiliary EOAs
 submission-accounts = [
   "<auxiliary-private-key-or-signer-config-1>",
   "<auxiliary-private-key-or-signer-config-2>",
@@ -27,28 +34,23 @@ submission-accounts = [
 ]
 ```
 
-The solver `account` must be able to sign the ERC-7702 authorization. Each `submission-accounts` entry must also be signer with a private key, not just an address.
+The solver `account` must be able to sign the ERC-7702 authorization. Each `submission-accounts` entry must also include signing credentials, not only an address.
 
-Fund each auxiliary EOA with native token for gas, as they will be used to submit transactions separately from the solver EOA.
+Fund each auxiliary EOA with the chain's native token so it can pay gas.
 
-When `submission-accounts` is configured, the reference driver:
-
-- sets up `Solver7702Delegate` during startup when the required signers are available;
-- uses the auxiliary accounts as extra settlement nonce lanes, when solver EOA is busy;
-- reuses the expected delegate deployment when the same code is already present;
-- refuses to start with `max-solutions-to-propose > 1` unless submission accounts are configured.
+At startup, the reference driver deploys `Solver7702Delegate` at the expected CREATE2 address, or reuses the existing deployment at that address. When the solver EOA is busy, it uses the auxiliary accounts to submit settlements through separate nonce lanes.
 
 ## What changes when submitting
 
-Direct submission should still be used when the solver EOA is free. Delegated submission is useful when the solver EOA already has a pending transaction and another settlement should be submitted without waiting for that nonce.
+When the solver EOA is free, it submits directly to `GPv2Settlement`. If it already has a pending transaction, an auxiliary EOA can submit to the solver EOA instead. The solver EOA runs `Solver7702Delegate`, which forwards the call to `GPv2Settlement`.
 
 ```mermaid
 flowchart LR
     SolverEOA{"Solver EOA"}
-    DirectTx["tx.from = solver EOA<br/>tx.to = GPv2Settlement<br/>tx.data = settle(...)"]
+    DirectTx["tx.data = settle(...)"]
     AuxEOAs{"Auxiliary EOAs<br/>0...N"}
-    DelegatedTx["tx.from = auxiliary EOA<br/>tx.to = solver EOA<br/>tx.data = bytes20(target)<br/>+ targetCalldata"]
-    DelegatedSolver["Solver EOA running<br/>Solver7702Delegate"]
+    DelegatedTx["tx.data = bytes20(target)<br/>|| targetCalldata"]
+    DelegatedSolver["Solver EOA<br/>delegated to Solver7702Delegate"]
     TargetCall["target = GPv2Settlement<br/>targetCalldata = settle(...)"]
     Settlement["GPv2Settlement"]
 
@@ -63,101 +65,26 @@ flowchart LR
     class DelegatedSolver,Settlement contract
 ```
 
-Inside the delegate, `msg.sender` is the auxiliary EOA and `address(this)` is the solver EOA. Inside `GPv2Settlement`, `msg.sender` is still the solver EOA.
-
 The calldata format is packed on purpose. Use `abi.encodePacked(bytes20(target), targetCalldata)`. Do not use `abi.encode(target, targetCalldata)`.
 
 ## Verification
 
-Before using delegated submission, verify both pieces:
-
-1. The solver EOA delegates to the expected delegate.
-2. The delegate bytecode matches the expected approved caller set.
-
-Check the solver EOA code:
+First, check that the solver EOA points to the expected delegate:
 
 ```shell
 cast code <solver_eoa> --rpc-url <rpc_url>
 ```
 
-For ERC-7702, delegated account code has this shape:
+For ERC-7702, the code has this form:
 
 ```text
-0xef0100 || delegateAddress
+0xef0100 || delegate_address
 ```
 
-The delegate bytecode check matters because approved callers are immutable constructor values. Do not only check that the delegate address has code.
+On a block explorer, the solver EOA may not have a normal contract code view. Confirm that its **Delegated to** banner points to the expected address, then open that address and verify its source as `Solver7702Delegate`.
 
-## Manual cast commands
-
-Most solvers should use the reference driver setup above. Use these commands only if you are setting up delegation manually and/or building a custom driver.
-
-**To authorize a delegate when the solver EOA sends its own authorization transaction, sign with `--self-broadcast`**:
-
-```shell
-cast wallet sign-auth <delegate_address> \
-  --private-key <solver_private_key> \
-  --rpc-url <rpc_url> \
-  --chain <chain_id> \
-  --self-broadcast
-
-cast send 0x0000000000000000000000000000000000000000 \
-  --auth <signed_authorization> \
-  --private-key <solver_private_key> \
-  --rpc-url <rpc_url> \
-  --chain <chain_id>
-```
-
-**If a different funded account sends either transaction, do not use `--self-broadcast` when signing.** The solver EOA signs the authorization, but the funded account pays gas and submits the transaction:
-
-```shell
-cast wallet sign-auth <delegate_or_zero_address> \
-  --private-key <solver_private_key> \
-  --rpc-url <rpc_url> \
-  --chain <chain_id>
-
-cast send 0x0000000000000000000000000000000000000000 \
-  --auth <signed_authorization> \
-  --private-key <transaction_sender_private_key> \
-  --rpc-url <rpc_url> \
-  --chain <chain_id>
-```
-
-To revoke delegation, sign an authorization to the zero address:
-
-```shell
-cast wallet sign-auth 0x0000000000000000000000000000000000000000 \
-  --private-key <solver_private_key> \
-  --rpc-url <rpc_url> \
-  --chain <chain_id> \
-  --self-broadcast
-
-cast send 0x0000000000000000000000000000000000000000 \
-  --auth <signed_authorization> \
-  --private-key <solver_private_key> \
-  --rpc-url <rpc_url> \
-  --chain <chain_id>
-```
-
-## Custom driver requirements
-
-If you do not use the reference driver, your driver must:
-
-- deploy `Solver7702Delegate` for the approved auxiliary caller set;
-- have the solver EOA delegate to the deployed `Solver7702Delegate`;
-- route delegated settlement transactions with `from = auxiliary EOA` and `to = solver EOA` (if solver EOA is busy);
-- encode delegated calldata as `bytes20(target) || targetCalldata`.
-
-## Capabilities and limits
-
-- Version 1 supports up to five immutable approved caller slots.
-- Approved auxiliary EOAs are trusted hot keys. They can trigger arbitrary calls as the solver EOA.
-- Changing authorized auxiliary accounts requires redeploying the delegate and re-delegating the solver EOA.
-- The delegate can call arbitrary targets. The driver should normally use `GPv2Settlement` for settlement submissions.
-- Use this only on chains and infrastructure that support ERC-7702 transaction authorization handling.
-
-Keep solver EOA funds and approvals minimal, do not share auxiliary EOAs across solvers, and rotate callers immediately if an auxiliary key is compromised.
+See the README's [verification steps](https://github.com/cowprotocol/solver-7702-delegate#verify-delegation) for details.
 
 ## More details
 
-For exact manual deployment, authorization, revocation, bytecode verification, and operational procedures, use the [`Solver7702Delegate` README](https://github.com/cowprotocol/solver-7702-delegate).
+For manual deployment, authorization, revocation, verification, and operational details, use the [`Solver7702Delegate` README](https://github.com/cowprotocol/solver-7702-delegate#usage).

--- a/docs/cow-protocol/tutorials/solvers/solver-7702-delegate.md
+++ b/docs/cow-protocol/tutorials/solvers/solver-7702-delegate.md
@@ -11,9 +11,9 @@ keywords:
 
 # Parallel Settlement Submission
 
-`Solver7702Delegate` lets a solver keep its existing allowlisted EOA and use auxiliary EOAs as additional nonce lanes for settlement submission.
+[`Solver7702Delegate`](https://github.com/cowprotocol/solver-7702-delegate/blob/main/src/Solver7702Delegate.sol) lets a solver keep its existing allowlisted EOA and use auxiliary EOAs as additional nonce lanes for settlement submission.
 
-Solvers expecting production volume should set this up early. With one EOA, a pending transaction can block every settlement behind it. Auxiliary EOAs can submit in parallel, while `GPv2Settlement` still sees the solver EOA as `msg.sender`.
+If a solver may submit more than one settlement at a time, it can set this up early. Ethereum executes transactions from the same EOA in nonce order, so one pending transaction can block subsequent settlement transactions. Auxiliary EOAs can submit in parallel, while `GPv2Settlement` still sees the solver EOA as `msg.sender`.
 
 :::warning
 
@@ -48,6 +48,8 @@ Fund each auxiliary EOA with the chain's native token so it can pay gas.
 
 At startup, the reference driver deploys `Solver7702Delegate` at the expected CREATE2 address, or reuses the existing deployment at that address. When the solver EOA is busy, it uses the auxiliary accounts to submit settlements through separate nonce lanes.
 
+The delegate is immutable. Approved auxiliary EOAs are hardcoded into the deployed bytecode, so the caller set cannot be changed after deployment. To change it, deploy a new delegate and re-delegate the solver EOA.
+
 ## What changes when submitting
 
 When the solver EOA is free, it submits directly to `GPv2Settlement`. If it already has a pending transaction, an auxiliary EOA can submit to the solver EOA instead. The solver EOA runs `Solver7702Delegate`, which forwards the call to `GPv2Settlement`.
@@ -56,19 +58,28 @@ When the solver EOA is free, it submits directly to `GPv2Settlement`. If it alre
 flowchart LR
     SolverEOA{"Solver EOA"}
     DirectTx["tx.data = settle(...)"]
-    AuxEOAs{"Auxiliary EOAs<br/>0...N"}
+    Aux1{"Auxiliary EOA 1"}
+    Aux2{"Auxiliary EOA 2"}
+    Aux3{"Auxiliary EOA 3"}
+    Aux4{"Auxiliary EOA 4"}
+    Aux5{"Auxiliary EOA 5"}
     DelegatedTx["tx.data = bytes20(target)<br/>|| targetCalldata"]
     DelegatedSolver["Solver EOA<br/>delegated to Solver7702Delegate"]
     TargetCall["target = GPv2Settlement<br/>targetCalldata = settle(...)"]
     Settlement["GPv2Settlement"]
 
     SolverEOA --> DirectTx --> Settlement
-    AuxEOAs --> DelegatedTx --> DelegatedSolver --> TargetCall --> Settlement
+    Aux1 --> DelegatedTx
+    Aux2 --> DelegatedTx
+    Aux3 --> DelegatedTx
+    Aux4 --> DelegatedTx
+    Aux5 --> DelegatedTx
+    DelegatedTx --> DelegatedSolver --> TargetCall --> Settlement
 
     classDef eoa fill:#fff3bf,stroke:#b08900,color:#1f2937
     classDef tx fill:#f3f0ff,stroke:#7048e8,color:#1f2937
     classDef contract fill:#1864ab,stroke:#0b3558,stroke-width:3px,color:#ffffff,font-weight:bold
-    class SolverEOA,AuxEOAs eoa
+    class SolverEOA,Aux1,Aux2,Aux3,Aux4,Aux5 eoa
     class DirectTx,DelegatedTx,TargetCall tx
     class DelegatedSolver,Settlement contract
 ```

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -204,7 +204,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
-      additionalLanguages: ['solidity', 'json'],
+      additionalLanguages: ['solidity', 'json', 'toml'],
     },
     colorMode: {
       defaultMode: 'light',


### PR DESCRIPTION
# Description

Adds a solver-facing guide for using `Solver7702Delegate` to keep the existing solver EOA while using auxiliary EOAs for parallel settlement submission.

# Changes

- [x] Add a new `Solver7702Delegate` tutorial under solver docs.
- [x] Document the direct vs delegated transaction shape and packed calldata format.
- [x] Cover setup, verification, monitoring, caller replacement, revocation, and compromised key handling.
- [x] Link the guide from solver onboarding and driver submission docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated solver driver documentation with configuration guidance for parallel settlement submissions.
  * Added new documentation page describing how to enable parallel settlement submissions using auxiliary accounts to prevent submission delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->