### PR TITLE
Document streaming quote API with per-network timeout guidance

### DIFF
--- a/docs/cow-protocol/integrate/api.mdx
+++ b/docs/cow-protocol/integrate/api.mdx
@@ -76,10 +76,10 @@ console.log('Order status:', orderDetails.status)
 ## Streaming Quotes
 
 `POST /api/v1/quote/stream` takes the same request body as `POST /api/v1/quote`, but returns a [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) stream instead of a single response.
-Each solver's quote arrives as its own event, so you can show a price as soon as the fastest solver responds instead of waiting for the whole competition.
+Each solver's quote arrives as its own event, so the client can show a price as soon as the fastest solver responds instead of waiting for the whole competition.
 
 Each event's `data` is an `OrderQuoteResponse`, the same shape `POST /api/v1/quote` returns, with `id` set to `null`.
-Solvers without a quote send nothing, so you may receive fewer events than there are solvers.
+Solvers without a quote send nothing, so the stream may contain fewer events than there are solvers.
 If no solver returns a usable quote, the server sends a final `error` event with a `NoLiquidity` body, then closes.
 
 ```bash
@@ -97,20 +97,20 @@ curl -N -X POST "https://api.cow.fi/mainnet/api/v1/quote/stream" \
 
 ### Choosing a timeout
 
-You receive each quote as soon as its solver responds, so a usable price arrives faster than with `POST /api/v1/quote`, which waits for the whole competition.
+Each quote is delivered as soon as its solver responds, so a usable price arrives faster than with `POST /api/v1/quote`, which waits for the whole competition.
 Streaming does not make any solver compute faster, though.
-The quote you act on is only as good as the responses that arrived before you stopped reading, and the `timeout` sets that boundary.
+The final quote is only as good as the responses that arrived before the stream was closed, and the `timeout` sets that boundary.
 
 The stream stays open until the request `timeout` elapses or every solver has responded.
 Slower solvers sometimes return a better price, especially on thin or unusual pairs that only one or two solvers can quote.
-A short timeout returns sooner, but it can leave you with a worse quote or none at all.
+A short timeout returns sooner, but it can yield a worse quote or none at all.
 A longer timeout gives the competition time to find a better price.
 
-You own this tradeoff.
-Set `timeout` (milliseconds) on the request, or read events and close the connection once you have a good-enough quote.
+This tradeoff is controlled by the client through the `timeout`.
+The value is set (in milliseconds) on the request, or the connection is closed once a good-enough quote has arrived.
 
 The table below is a starting point, not a guarantee.
-Measure against your own traffic, and raise the timeout for pairs that only slower solvers can price.
+The values should be measured against real traffic and raised for pairs that only slower solvers can price.
 Response times also differ by network, and these values shift as solver performance changes (guidance as of 2026-06).
 
 | Network | `timeout` (ms) |

--- a/docs/cow-protocol/integrate/api.mdx
+++ b/docs/cow-protocol/integrate/api.mdx
@@ -75,9 +75,12 @@ console.log('Order status:', orderDetails.status)
 
 ## Streaming Quotes
 
-`POST /api/v1/quote/stream` takes the same request body as `POST /api/v1/quote` but returns a [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) stream instead of one response. Each solver's quote arrives as its own event, so you can show prices as they come in instead of waiting for the slowest solver.
+`POST /api/v1/quote/stream` takes the same request body as `POST /api/v1/quote`, but returns a [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) stream instead of a single response.
+Each solver's quote arrives as its own event, so you can show a price as soon as the fastest solver responds instead of waiting for the whole competition.
 
-Each event's `data` is an `OrderQuoteResponse`, the same shape `POST /api/v1/quote` returns, with `id` set to `null`. Solvers without a quote send nothing, so you may receive fewer events than there are solvers. If no solver returns a usable quote, the server sends a final `error` event with a `NoLiquidity` body, then closes.
+Each event's `data` is an `OrderQuoteResponse`, the same shape `POST /api/v1/quote` returns, with `id` set to `null`.
+Solvers without a quote send nothing, so you may receive fewer events than there are solvers.
+If no solver returns a usable quote, the server sends a final `error` event with a `NoLiquidity` body, then closes.
 
 ```bash
 curl -N -X POST "https://api.cow.fi/mainnet/api/v1/quote/stream" \
@@ -94,11 +97,21 @@ curl -N -X POST "https://api.cow.fi/mainnet/api/v1/quote/stream" \
 
 ### Choosing a timeout
 
-The client side owns this decision. The stream stays open until the request `timeout` elapses, or every solver has responded, so the value you set determines both how long you wait and which quotes you see. Set `timeout` (milliseconds) on the request, or close the connection yourself once you have a good-enough quote.
+You receive each quote as soon as its solver responds, so a usable price arrives faster than with `POST /api/v1/quote`, which waits for the whole competition.
+Streaming does not make any solver compute faster, though.
+The quote you act on is only as good as the responses that arrived before you stopped reading, and the `timeout` sets that boundary.
 
-Streaming delivers quotes as they arrive, but it doesn't make any solver respond faster, so it isn't simply a quicker `/quote`. How much a short timeout helps depends on the pair: fast solvers cover liquid pairs in a few hundred milliseconds, while a thinner pair might rely on a single slower solver that a tight timeout would miss. It's worth tuning the value to the pairs you serve.
+The stream stays open until the request `timeout` elapses or every solver has responded.
+Slower solvers sometimes return a better price, especially on thin or unusual pairs that only one or two solvers can quote.
+A short timeout returns sooner, but it can leave you with a worse quote or none at all.
+A longer timeout gives the competition time to find a better price.
 
-Treat the values below as a starting point, not a guarantee. Measure against your own traffic, and raise the timeout for pairs that only slower solvers can price. Quote response times also differ by network. These are guidance as of 2026-06 and shift as solver performance changes.
+You own this tradeoff.
+Set `timeout` (milliseconds) on the request, or read events and close the connection once you have a good-enough quote.
+
+The table below is a starting point, not a guarantee.
+Measure against your own traffic, and raise the timeout for pairs that only slower solvers can price.
+Response times also differ by network, and these values shift as solver performance changes (guidance as of 2026-06).
 
 | Network | `timeout` (ms) |
 |---|---|

--- a/docs/cow-protocol/integrate/api.mdx
+++ b/docs/cow-protocol/integrate/api.mdx
@@ -9,6 +9,7 @@ The API integration allows you to interact with CoW Protocol at the lowest level
 ## Key APIs
 
 ### Order Book API
+
 The primary API for creating and managing orders on CoW Protocol.
 
 - **Base URL**: `https://api.cow.fi/`
@@ -18,6 +19,7 @@ The primary API for creating and managing orders on CoW Protocol.
 ### Key Endpoints
 
 - `POST /api/v1/quote` - Get trading quotes
+- `POST /api/v1/quote/stream` - Stream quotes from individual solvers as they arrive (SSE)
 - `POST /api/v1/orders` - Submit signed orders
 - `GET /api/v1/orders/{uid}` - Get order details
 - `DELETE /api/v1/orders/{uid}` - Cancel orders
@@ -70,6 +72,39 @@ const orderDetails = await orderResponse.json()
 
 console.log('Order status:', orderDetails.status)
 ```
+
+## Streaming Quotes
+
+`POST /api/v1/quote/stream` takes the same request body as `POST /api/v1/quote` but returns a [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) stream instead of one response. Each solver's quote arrives as its own event, so you can show prices as they come in instead of waiting for the slowest solver.
+
+Each event's `data` is an `OrderQuoteResponse`, the same shape `POST /api/v1/quote` returns, with `id` set to `null`. Solvers without a quote send nothing, so you may receive fewer events than there are solvers. If no solver returns a usable quote, the server sends a final `error` event with a `NoLiquidity` body, then closes.
+
+```bash
+curl -N -X POST "https://api.cow.fi/mainnet/api/v1/quote/stream" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{
+    "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    "buyToken": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    "sellAmountBeforeFee": "1000000000000000000",
+    "kind": "sell",
+    "from": "0xYourWalletAddress"
+  }'
+```
+
+### Choosing a timeout
+
+The client side owns this decision. The stream stays open until the request `timeout` elapses, or every solver has responded, so the value you set determines both how long you wait and which quotes you see. Set `timeout` (milliseconds) on the request, or close the connection yourself once you have a good-enough quote.
+
+Streaming delivers quotes as they arrive, but it doesn't make any solver respond faster, so it isn't simply a quicker `/quote`. How much a short timeout helps depends on the pair: fast solvers cover liquid pairs in a few hundred milliseconds, while a thinner pair might rely on a single slower solver that a tight timeout would miss. It's worth tuning the value to the pairs you serve.
+
+Treat the values below as a starting point, not a guarantee. Measure against your own traffic, and raise the timeout for pairs that only slower solvers can price. Quote response times also differ by network. These are guidance as of 2026-06 and shift as solver performance changes.
+
+| Network | `timeout` (ms) |
+|---|---|
+| Base, Gnosis Chain, Linea | 1000 |
+| Mainnet, BNB Chain | 1800 |
+| Arbitrum, Polygon, Avalanche, Ink | 2500 |
 
 ## Network Endpoints
 
@@ -164,3 +199,4 @@ For complete API documentation including all endpoints, parameters, and response
 - **[API Explorer](https://api.cow.fi/docs/)** - Interactive documentation
 - **[GitHub Examples](https://github.com/cowprotocol/cow-sdk/tree/main/examples)** - Code examples
 - **[Order Signing Guide](../reference/core/signing_schemes.mdx)** - Cryptographic signing details
+

--- a/docs/cow-protocol/integrate/api.mdx
+++ b/docs/cow-protocol/integrate/api.mdx
@@ -78,7 +78,8 @@ console.log('Order status:', orderDetails.status)
 `POST /api/v1/quote/stream` takes the same request body as `POST /api/v1/quote`, but returns a [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) stream instead of a single response.
 Each solver's quote arrives as its own event, so the client can show a price as soon as the fastest solver responds instead of waiting for the whole competition.
 
-Each event's `data` is an `OrderQuoteResponse`, the same shape `POST /api/v1/quote` returns, with `id` set to `null`.
+Each event's `data` is an `OrderQuoteResponse`, the same shape `POST /api/v1/quote` returns.
+The `id` on each event can be passed as `quoteId` when placing an order, the same as a quote from `POST /api/v1/quote`.
 Solvers without a quote send nothing, so the stream may contain fewer events than there are solvers.
 If no solver returns a usable quote, the server sends a final `error` event with a `NoLiquidity` body, then closes.
 


### PR DESCRIPTION
# Description
The new streaming quote endpoint (`POST /api/v1/quote/stream`) needs to be covered with docs. Integrators need to know it streams per-solver quotes over SSE, that they control the `timeout`, and that it is not simply a faster `/quote`: on a thin pair that only a slow solver can price, a short timeout drops that quote.

# Changes
- Added `POST /api/v1/quote/stream` to the Key Endpoints list
- Added a "Streaming Quotes" section covering SSE behavior, event shape, a curl example, and timeout guidance with per-network suggestions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for streaming quotes through the API, including the new `POST /api/v1/quote/stream` endpoint.
  * Documented the SSE response behavior, including per-solver quote events and when an `error` event is emitted.
  * Added timeout guidance to control how long the stream remains open and influence returned quote quality.
  * Updated the resources section with an Order Signing Guide link and made minor formatting improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->