### PR TITLE
Update the shadow competition onboarding for solvers

### DIFF
--- a/docs/cow-protocol/tutorials/solvers/onboard.md
+++ b/docs/cow-protocol/tutorials/solvers/onboard.md
@@ -143,7 +143,7 @@ We advise using a single rewards address that is available on all networks.
 
 ## 8. Moving to other networks
 
-After joining the solver competition on Arbitrum we can enable your solver on other chains relatively soon. For this we will go through the same process of generating addresses, vouching for them, and whitelisting them. For each new chain that we deploy your solver on we will need:
+After joining the solver competition on BNB we can enable your solver on other chains relatively soon. For this we will go through the same process of generating addresses, vouching for them, and whitelisting them. For each new chain that we deploy your solver on we will need:
 
 - A rewards address for receiving the weekly COW rewards associated with that network;
 - An endpoint that you would like to use for staging amd production.

--- a/docs/cow-protocol/tutorials/solvers/onboard.md
+++ b/docs/cow-protocol/tutorials/solvers/onboard.md
@@ -36,7 +36,7 @@ The general KYC requirements are as follows:
 
 Do not send this before the meeting, we will explain the process during the meeting so that you can send the documents afterwards. We usually expect the KYC process to take about 1 to 3 working days, but it may vary.
 
-Given the risk that will be carried by the CoW DAO bonding pool we also ask that solvers who join the solver competition through the CoW DAO bonding pool start solving on Arbitrum first. After being in production on Arbitrum solvers can move to other L2's relatively easily. But joining the mainnet competition will require further evaluation after some time of solving on L2's.
+Given the risk that will be carried by the CoW DAO bonding pool we also ask that solvers who join the solver competition through the CoW DAO bonding pool start solving on BNB Chain first. After being in production on BNB Chain solvers can move to other L2's relatively easily. But joining the mainnet competition will require further evaluation after some time of solving on L2's.
 
 ### Service fees
 


### PR DESCRIPTION
# Description

This PR updates the onboarding instructions for solvers joining the shadow competition.

# Changes

- Updated onboarding to show 'BNB Chain' instead of 'Arbitrum'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated solver onboarding guidance to recommend starting on **BNB Chain** rather than **Arbitrum**, with guidance on enabling solvers on other chains soon afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->