### PR TITLE
Fix invalid WETH address and wrong BNB explorer links in competition rules

### DIFF
--- a/docs/cow-protocol/reference/core/auctions/competition_rules.md
+++ b/docs/cow-protocol/reference/core/auctions/competition_rules.md
@@ -117,7 +117,7 @@ At CoW DAO's discretion, systematic violation of these rules may lead to penaliz
     <summary>Base chain baseline protocols and tokens</summary>
 
   - **Protocols**: Uniswap v2/v3, Balancer v2
-  - **Base tokens**: [`WETH`](https://basescan.org/address/0x420000000000000000000000000000000000000), [`USDC`](https://basescan.org/address/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913), [`DAI`](https://basescan.org/address/0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb)
+  - **Base tokens**: [`WETH`](https://basescan.org/address/0x4200000000000000000000000000000000000006), [`USDC`](https://basescan.org/address/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913), [`DAI`](https://basescan.org/address/0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb)
   </details>
 
   <details>
@@ -138,7 +138,7 @@ At CoW DAO's discretion, systematic violation of these rules may lead to penaliz
     <summary>BNB chain baseline protocols and tokens</summary>
 
   - **Protocols**: Uniswap v2/v3, Pancake Swap
-  - **Base tokens**: [`WBNB`](https://bnbscan.com/address/0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c), [`BUSD`](https://bnbscan.com/address/0xe9e7cea3dedca5984780bafc599bd69add087d56), [`USDT`](https://bnbscan.com/address/0x55d398326f99059ff775485246999027b3197955), [`WETH`](https://bnbscan.com/address/0x2170ed0880ac9a755fd29b2688956bd959f933f8)
+  - **Base tokens**: [`WBNB`](https://bscscan.com/address/0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c), [`BUSD`](https://bscscan.com/address/0xe9e7cea3dedca5984780bafc599bd69add087d56), [`USDT`](https://bscscan.com/address/0x55d398326f99059ff775485246999027b3197955), [`WETH`](https://bscscan.com/address/0x2170ed0880ac9a755fd29b2688956bd959f933f8)
   </details>
 
   <details>


### PR DESCRIPTION
# Description

Two link fixes in the competition rules baseline-token sections. The Base chain baseline links WETH to `0x420000000000000000000000000000000000000`, which is 39 hex characters and not a valid address. The BNB chain baseline's four explorer links point at bnbscan.com rather than the canonical BNB Chain explorer (bscscan.com).

# Changes

- [x] Base baseline: corrected the WETH link target to the canonical Base WETH `0x4200000000000000000000000000000000000006` (on-chain `symbol()` returns `WETH`).
- [x] BNB baseline: replaced bnbscan.com with bscscan.com in four links. The addresses themselves are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Base chain WETH address reference to the canonical address.
  * Corrected BNB chain token links to use BscScan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->