### PR TITLE
Replace rule on positive score

### DIFF
--- a/docs/cow-protocol/reference/core/auctions/competition_rules.md
+++ b/docs/cow-protocol/reference/core/auctions/competition_rules.md
@@ -21,7 +21,7 @@ All solvers participating in the solver competition must abide by certain rules.
 - Scores: Every solution is associated with a _score_. The score is computed from executed amounts of all trades and is roughly equivalent to the amount of surplus a solution generates for users. For concrete formulas see [the section on solving](the-problem) or [CIP-38](https://snapshot.box/#/s:cow.eth/proposal/0xfb81daea9be89f4f1c251d53fd9d1481129b97c6f38caaddc42af7f3ce5a52ec) and [CIP-65](https://snapshot.box/#/s:cow.eth/proposal/0xd172281444c48254398881c57a57a2acbf0802a385e6c94384fd358b943aa4f4).
 
 - Valid solutions: A solution is _valid_ if
-  - it has a positive score; and
+  - it proposes the execution of at least one order eligible for contributing to score; and
   - respects Uniform Directional Clearing Prices (UDCP): all orders trading the same tokens in the same direction must receive the same price (with an exception for orders containing hooks to account for the cost of gas). Importantly, each solution must respect UDCP, but there is no obligation to respect UDCP across solutions, even if submitted by the same solver.
 
 - Winner selection: The set of winning solutions (and corresponding winning solvers) is chosen using a _Fair Combinatorial Auction_ (see [CIP-67](https://snapshot.box/#/s:cow.eth/proposal/0xf9ecb08c4738f04c4525373d6b78085d16635f86adacd1b8ea77b2c176c99d32)) from all valid solutions. Each solution corresponds to a bid in the auction.


### PR DESCRIPTION
This PR aligns the documentation with the changes implemented in [this PR in the autopilot](https://github.com/cowprotocol/services/pull/4753).

Before, every solution with a score of zero was filtered out as invalid. This is problematic for som esolutions where tokens with few decimals are traded. Giving a small amount of surplus in such tokens might not be possible while executing at zero surplus can reasonably be regarded as better than not executing.

With combinatorial auctions and multiple winners, the old argument around a solution with zero score not beating the empty solution is also not valid anymore. The winner selection would pick both in such cases.

To avoid issues with solvers submitting actually emty solutions, we now require valid solutions to propose the execution of at least one order which can contribute to score. This currently includes orders from the orderbook and jit orders created by addresses on the list of surplus capturing jit order owners. It excludes (jit) liquidity orders.
